### PR TITLE
Tighten tokenizer metadata checks

### DIFF
--- a/scripts/tokenizer_diagnostics.py
+++ b/scripts/tokenizer_diagnostics.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""分词器健康度诊断工具。
+
+功能：
+- 校验 tokenizer 配置与元数据
+- 统计随机样本的 UNK 占比
+- 输出基础统计，帮助排查预训练/推理分词器不匹配问题
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import pprint
+import os
+import random
+import sys
+from typing import Iterable, Iterator, List
+
+# 添加项目根目录和src目录到路径
+PROJECT_ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.append(PROJECT_ROOT)
+sys.path.append(os.path.join(PROJECT_ROOT, "src"))
+
+from tokenizer.bpe_tokenizer import BPETokenizer  # noqa: E402
+
+try:
+    import torch
+except ImportError:  # pragma: no cover - fallback for minimal environments
+    torch = None
+
+
+def iter_texts_from_jsonl(path: str) -> Iterator[str]:
+    with open(path, "r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if "text" in record and record["text"]:
+                yield str(record["text"])
+            elif "conversations" in record:
+                for turn in record["conversations"]:
+                    content = turn.get("content")
+                    if content:
+                        yield str(content)
+            elif "input" in record and "output" in record:
+                yield f"{record['input']} {record['output']}"
+            elif "chosen" in record:
+                yield str(record["chosen"])
+
+
+def iter_texts_from_plain(path: str) -> Iterator[str]:
+    with open(path, "r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if line:
+                yield line
+
+
+def collect_texts(path: str, sample_size: int, seed: int) -> List[str]:
+    if path.endswith(".jsonl"):
+        iterator: Iterable[str] = iter_texts_from_jsonl(path)
+    else:
+        iterator = iter_texts_from_plain(path)
+
+    if sample_size <= 0:
+        return list(iterator)
+
+    reservoir: List[str] = []
+    rng = random.Random(seed)
+    for idx, text in enumerate(iterator):
+        if not text:
+            continue
+        if len(reservoir) < sample_size:
+            reservoir.append(text)
+        else:
+            j = rng.randint(0, idx)
+            if j < sample_size:
+                reservoir[j] = text
+    rng.shuffle(reservoir)
+    return reservoir
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="MiniGPT 分词器诊断工具")
+    parser.add_argument("--tokenizer", required=True, help="tokenizer.pkl 路径")
+    parser.add_argument("--data", help="用于统计UNK率的数据文件 (jsonl 或 txt)")
+    parser.add_argument("--sample-size", type=int, default=1000, help="随机抽样样本数")
+    parser.add_argument("--seed", type=int, default=42, help="随机种子")
+    parser.add_argument("--checkpoint", help="用于对比元数据的checkpoint路径")
+
+    args = parser.parse_args()
+
+    tokenizer = BPETokenizer()
+    tokenizer.load(args.tokenizer)
+
+    print("=== Tokenizer 信息 ===")
+    print(f"文件: {args.tokenizer}")
+    print(f"词汇表大小: {tokenizer.vocab_size}")
+    print(f"配置: {tokenizer.get_config()}")
+    print(f"Checksum: {tokenizer.checksum() or 'N/A'}")
+    print("特殊Token映射:")
+    pprint.pprint(tokenizer.special_tokens_map(require_presence=bool(tokenizer.vocab)))
+
+    if args.checkpoint:
+        if torch is None:
+            print("⚠️  未安装torch，无法加载checkpoint进行对比")
+        elif not os.path.exists(args.checkpoint):
+            raise FileNotFoundError(f"checkpoint不存在: {args.checkpoint}")
+        else:
+            checkpoint = torch.load(args.checkpoint, map_location="cpu", weights_only=False)
+            expected_config = checkpoint.get("tokenizer_config")
+            if expected_config:
+                actual_config = tokenizer.get_config()
+                mismatches = {
+                    key: (expected_config[key], actual_config.get(key))
+                    for key in expected_config
+                    if actual_config.get(key) != expected_config[key]
+                }
+                if mismatches:
+                    print("⚠️  配置不一致:")
+                    for key, values in mismatches.items():
+                        print(f"   {key}: checkpoint={values[0]} tokenizer={values[1]}")
+                else:
+                    print("✅ checkpoint 配置匹配")
+            expected_special = checkpoint.get("tokenizer_special_tokens")
+            if expected_special:
+                special_mismatches = tokenizer.diff_special_tokens(expected_special)
+                if special_mismatches:
+                    print("⚠️  特殊token映射不一致:")
+                    for name, (exp, act) in special_mismatches.items():
+                        print(f"   {name}: checkpoint={exp} tokenizer={act}")
+                else:
+                    print("✅ 特殊token映射匹配")
+
+    if not args.data:
+        print("未提供数据文件，跳过 UNK 率统计。")
+        return
+
+    if not os.path.exists(args.data):
+        raise FileNotFoundError(f"数据文件不存在: {args.data}")
+
+    texts = collect_texts(args.data, args.sample_size, args.seed)
+    if not texts:
+        print("⚠️  样本为空，无法统计 UNK 率")
+        return
+
+    stats = tokenizer.compute_unk_statistics(texts, sample_size=len(texts))
+    print("\n=== UNK 统计 ===")
+    print(f"样本条数: {stats['sampled_texts']}")
+    print(f"总token数: {stats['total_tokens']}")
+    print(f"UNK数量: {stats['unk_tokens']}")
+    print(f"UNK率: {stats['unk_rate']*100:.4f}%")
+
+    if stats["unk_rate"] > 0.001:
+        print("⚠️  UNK率偏高，建议检查 tokenizer 配置、训练/推理规范化流程或是否启用 byte fallback。")
+    else:
+        print("✅ UNK率处于正常范围")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tokenizer/bpe_tokenizer.py
+++ b/src/tokenizer/bpe_tokenizer.py
@@ -2,269 +2,422 @@
 手写实现BPE (Byte Pair Encoding) Tokenizer
 用于新手教学理解分词原理，优化了中文处理
 """
+from __future__ import annotations
+
+import hashlib
 import json
+import pickle
+import random
 import re
 import time
-import sys
-import random
-import os
-from typing import List, Dict, Tuple, Optional
-from collections import defaultdict, Counter
-import pickle
-from multiprocessing import Pool, cpu_count
-from functools import partial
+import unicodedata
+from collections import defaultdict
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 
-def is_chinese_char(char):
-    """判断是否为中文字符"""
-    return '\u4e00' <= char <= '\u9fff'
+CJK_RANGES: List[Tuple[str, str]] = [
+    ("\u4e00", "\u9fff"),  # CJK Unified Ideographs
+    ("\u3400", "\u4dbf"),  # CJK Extension A
+    ("\u3040", "\u309f"),  # Hiragana
+    ("\u30a0", "\u30ff"),  # Katakana
+    ("\u31f0", "\u31ff"),  # Katakana Phonetic Extensions
+    ("\uAC00", "\uD7AF"),  # Hangul syllables
+]
 
 
-def print_progress_bar(current: int, total: int, prefix: str = '', suffix: str = '', 
-                      decimals: int = 1, length: int = 40, fill: str = '█', 
-                      empty: str = '░'):
-    """打印动态进度条，会覆盖上一行"""
+def is_chinese_char(char: str) -> bool:
+    """判断是否为中日韩字符（兼容原函数名称）。"""
+
+    return any(start <= char <= end for start, end in CJK_RANGES)
+
+
+def print_progress_bar(
+    current: int,
+    total: int,
+    prefix: str = "",
+    suffix: str = "",
+    decimals: int = 1,
+    length: int = 40,
+    fill: str = "█",
+    empty: str = "░",
+) -> None:
+    """打印动态进度条，会覆盖上一行。"""
+
     percent = ("{0:." + str(decimals) + "f}").format(100 * (current / float(total)))
     filled_length = int(length * current // total)
     bar = fill * filled_length + empty * (length - filled_length)
-    
-    # 使用 \r 回到行首，覆盖上一行内容
-    print(f'\r{prefix} |{bar}| {percent}% {suffix}', end='', flush=True)
-    
-    # 如果完成，换行
+    print(f"\r{prefix} |{bar}| {percent}% {suffix}", end="", flush=True)
     if current == total:
         print()
 
 
-def show_progress_with_stats(current: int, total: int, start_time: float, 
-                           prefix: str = '', extra_info: str = ''):
-    """统一的进度显示函数，包含速度和预计完成时间"""
+def show_progress_with_stats(
+    current: int,
+    total: int,
+    start_time: float,
+    prefix: str = "",
+    extra_info: str = "",
+) -> None:
+    """统一的进度显示函数，包含速度和预计完成时间。"""
+
     elapsed = time.time() - start_time
     speed = current / elapsed if elapsed > 0 else 0
     eta = (total - current) / speed if speed > 0 else 0
-    
+
     suffix = f"({current:,}/{total:,}) {speed:.0f}/秒"
     if eta > 0:
         suffix += f" ETA: {eta:.0f}秒"
     if extra_info:
         suffix += f" | {extra_info}"
-    
+
     print_progress_bar(current, total, prefix=prefix, suffix=suffix)
 
 
 class BPETokenizer:
-    """BPE分词器实现 - 优化了中文处理
-    
-    BPE算法核心思想：
-    1. 将文本分割成字符
-    2. 统计相邻字符对的频率
-    3. 合并频率最高的字符对
-    4. 重复步骤2-3直到达到词汇表大小
-    """
-    
-    def __init__(self, vocab_size: int = 30000):  # 增加默认词汇表大小
+    """BPE分词器实现 - 优化了中文处理并支持字节回退。"""
+
+    def __init__(
+        self,
+        vocab_size: int = 30000,
+        *,
+        lowercase: bool = True,
+        normalize_nfkc: bool = True,
+        strip_spaces: bool = True,
+        enable_byte_fallback: bool = True,
+    ) -> None:
         self.vocab_size = vocab_size
-        self.word_freqs = {}  # 词频统计
-        self.splits = {}      # 词的分割结果
-        self.merges = {}      # 合并规则
-        self.vocab = {}       # 词汇表
-        
+        self.lowercase = lowercase
+        self.normalize_nfkc = normalize_nfkc
+        self.strip_spaces = strip_spaces
+        self.enable_byte_fallback = enable_byte_fallback
+
+        self.word_freqs: Dict[str, int] = {}
+        self.splits: Dict[str, List[str]] = {}
+        self.merges: Dict[Tuple[str, str], int] = {}
+        self.vocab: Dict[str, int] = {}
+
         # 特殊token
-        self.pad_token = '<PAD>'
-        self.unk_token = '<UNK>'
-        self.bos_token = '<BOS>'  # Begin of sequence
-        self.eos_token = '<EOS>'  # End of sequence
-        
+        self.pad_token = "<PAD>"
+        self.unk_token = "<UNK>"
+        self.bos_token = "<BOS>"
+        self.eos_token = "<EOS>"
+
         # 特殊token的ID
         self.pad_id = 0
         self.unk_id = 1
         self.bos_id = 2
         self.eos_id = 3
-        
+
+        # Byte fallback配置
+        self.byte_eow_token = "<BYTE_EOW>"
+        self._byte_token_prefix = "<0x"
+        self._byte_token_pattern = re.compile(r"<0x([0-9A-Fa-f]{2})>")
+        self._reserved_special_tokens = 4
+        self._checksum: str = ""
+
+        self._update_reserved_token_count()
+        self._sync_internal_state()
+
+    # ------------------------------------------------------------------
+    def _normalizer_signature(self) -> str:
+        """Return a stable signature that describes the normalization pipeline."""
+
+        stages: List[str] = []
+        if self.normalize_nfkc:
+            stages.append("nfkc")
+        if self.strip_spaces:
+            stages.append("strip_spaces")
+        if self.lowercase:
+            stages.append("lowercase")
+        return "+".join(stages) if stages else "identity"
+
+    # ------------------------------------------------------------------
+    def _update_reserved_token_count(self) -> None:
+        if self.enable_byte_fallback:
+            minimum_vocab = self._reserved_special_tokens + 257
+            if self.vocab_size < minimum_vocab:
+                print(
+                    f"⚠️  vocab_size={self.vocab_size} 太小，无法启用 byte fallback，自动禁用。"
+                )
+                self.enable_byte_fallback = False
+        self._reserved_byte_tokens = 257 if self.enable_byte_fallback else 0
+        self._reserved_token_count = self._reserved_special_tokens + self._reserved_byte_tokens
+
+    def _format_byte_token(self, value: int) -> str:
+        return f"<0x{value:02X}>"
+
+    def _normalize(self, text: str) -> str:
+        if self.normalize_nfkc:
+            text = unicodedata.normalize("NFKC", text)
+        if self.strip_spaces:
+            text = re.sub(r"\s+", " ", text).strip()
+        if self.lowercase:
+            text = text.lower()
+        return text
+
+    def _sync_internal_state(self) -> None:
+        """重建内部映射信息。"""
+
+        self._id_to_token: Dict[int, str] = {v: k for k, v in self.vocab.items()}
+        if self.enable_byte_fallback and self.vocab:
+            self.byte_token_to_id = {}
+            self.id_to_byte = {}
+            for byte in range(256):
+                token = self._format_byte_token(byte)
+                if token in self.vocab:
+                    idx = self.vocab[token]
+                    self.byte_token_to_id[byte] = idx
+                    self.id_to_byte[idx] = byte
+            self.byte_eow_id = self.vocab.get(self.byte_eow_token)
+        else:
+            self.byte_token_to_id = {}
+            self.id_to_byte = {}
+            self.byte_eow_id = None
+
+    def _validate_special_tokens(self, require_presence: bool = False, *, strict: bool = True) -> None:
+        """Ensure special tokens exist at the expected ids."""
+
+        expected = {
+            self.pad_token: self.pad_id,
+            self.unk_token: self.unk_id,
+            self.bos_token: self.bos_id,
+            self.eos_token: self.eos_id,
+        }
+        if self.enable_byte_fallback:
+            if self.byte_eow_id is None:
+                if require_presence:
+                    raise ValueError("启用了 byte fallback 但缺少 BYTE_EOW token")
+            else:
+                expected[self.byte_eow_token] = self.byte_eow_id
+
+        for token, expected_id in expected.items():
+            actual_id = self.vocab.get(token)
+            if actual_id is None:
+                if require_presence and strict:
+                    raise ValueError(f"缺少特殊token: {token}")
+                continue
+            if actual_id != expected_id:
+                if strict:
+                    raise ValueError(
+                        f"特殊token {token} 的ID不匹配: 期望 {expected_id}, 实际 {actual_id}"
+                    )
+
+    def _checksum_payload(self) -> Dict[str, Any]:
+        return {
+            "vocab": sorted(self.vocab.items()),
+            "merges": sorted(self.merges.items()),
+            "config": self.get_config(),
+        }
+
+    def _update_checksum(self) -> None:
+        payload = pickle.dumps(self._checksum_payload(), protocol=4)
+        self._checksum = hashlib.sha256(payload).hexdigest()
+
+    def _is_cjk_string(self, text: str) -> bool:
+        return bool(text) and all(is_chinese_char(ch) for ch in text)
+
+    def _should_add_space(self, text: str) -> bool:
+        if not text:
+            return False
+        if self._is_cjk_string(text):
+            return False
+        return any(ch.isalnum() for ch in text)
+
+    def _postprocess_text(self, text: str) -> str:
+        if self.strip_spaces:
+            text = re.sub(r"\s+", " ", text)
+        text = re.sub(r"([\u4e00-\u9fff])\s+([\u4e00-\u9fff])", r"\1\2", text)
+        text = re.sub(r"([\u4e00-\u9fff])\s+([\u3000-\u303F\uFF00-\uFFEF.,!?;:，。！？；：])", r"\1\2", text)
+        text = re.sub(r"([\u3000-\u303F\uFF00-\uFFEF.,!?;:，。！？；：])\s+([\u4e00-\u9fff])", r"\1\2", text)
+        text = re.sub(r"\s+([,.!?;:，。！？；：])", r"\1", text)
+        return text.strip()
+
+    def _encode_as_bytes(self, text: str) -> List[int]:
+        if not self.enable_byte_fallback:
+            return [self.unk_id]
+        try:
+            data = text.encode("utf-8")
+        except Exception:
+            data = text.encode("utf-8", errors="ignore")
+        token_ids: List[int] = []
+        for byte in data:
+            token = self._format_byte_token(byte)
+            if token in self.vocab:
+                token_ids.append(self.vocab[token])
+            else:
+                # 如果缺失fallback token，退化为UNK
+                return [self.unk_id]
+        if self.byte_eow_id is not None:
+            token_ids.append(self.byte_eow_id)
+        return token_ids or [self.unk_id]
+
+    # ------------------------------------------------------------------
     def pre_tokenize(self, text: str) -> List[str]:
         """预分词：改进中文处理"""
-        # 针对中文优化的预分词规则
-        words = []
+
+        text = self._normalize(text)
+        words: List[str] = []
         current_word = ""
-        
+
         for char in text:
             if is_chinese_char(char):
-                # 中文字符作为独立的词
                 if current_word:
-                    words.append(current_word.lower())
+                    words.append(current_word)
                     current_word = ""
                 words.append(char)
             elif char.isalnum():
-                # 英文/数字字符累积
                 current_word += char
             elif char.isspace():
-                # 空格分隔
                 if current_word:
-                    words.append(current_word.lower())
+                    words.append(current_word)
                     current_word = ""
             else:
-                # 标点符号
                 if current_word:
-                    words.append(current_word.lower())
+                    words.append(current_word)
                     current_word = ""
-                if char.strip():  # 非空白标点
+                if char.strip():
                     words.append(char)
-        
-        # 处理最后的词
+
         if current_word:
-            words.append(current_word.lower())
-        
-        return [w for w in words if w.strip()]  # 过滤空词
-    
-    def compute_word_frequencies(self, texts: List[str]):
+            words.append(current_word)
+
+        return [w for w in words if w.strip()]
+
+    def compute_word_frequencies(self, texts: List[str]) -> None:
         """计算词频"""
+
         word_freqs = defaultdict(int)
-        
         print("正在计算词频...")
         start_time = time.time()
         total_texts = len(texts)
-        
+
         for i, text in enumerate(texts):
             words = self.pre_tokenize(text)
             for word in words:
                 word_freqs[word] += 1
-            
-            # 显示动态进度
             if (i + 1) % 1000 == 0 or i == total_texts - 1:
-                show_progress_with_stats(i + 1, total_texts, start_time, prefix='词频计算')
-        
-        # 针对中文优化的过滤策略
+                show_progress_with_stats(i + 1, total_texts, start_time, prefix="词频计算")
+
         original_vocab_size = len(word_freqs)
-        
-        # 中文字符保留更低的频率阈值
-        chinese_chars = {word: freq for word, freq in word_freqs.items() 
-                        if len(word) == 1 and is_chinese_char(word)}
-        other_words = {word: freq for word, freq in word_freqs.items() 
-                      if not (len(word) == 1 and is_chinese_char(word))}
-        
-        # 中文字符：频率>=1
-        # 其他词：根据总词汇量动态调整
+        chinese_chars = {
+            word: freq
+            for word, freq in word_freqs.items()
+            if len(word) == 1 and is_chinese_char(word)
+        }
+        other_words = {
+            word: freq
+            for word, freq in word_freqs.items()
+            if not (len(word) == 1 and is_chinese_char(word))
+        }
+
         min_freq_chinese = 1
         min_freq_other = 2 if len(other_words) <= 30000 else max(2, len(other_words) // 15000)
-        
-        filtered_word_freqs = {}
-        filtered_word_freqs.update({word: freq for word, freq in chinese_chars.items() 
-                                  if freq >= min_freq_chinese})
-        filtered_word_freqs.update({word: freq for word, freq in other_words.items() 
-                                  if freq >= min_freq_other})
-        
+
+        filtered_word_freqs: Dict[str, int] = {}
+        filtered_word_freqs.update({word: freq for word, freq in chinese_chars.items() if freq >= min_freq_chinese})
+        filtered_word_freqs.update({word: freq for word, freq in other_words.items() if freq >= min_freq_other})
+
         self.word_freqs = filtered_word_freqs
         elapsed = time.time() - start_time
-        
-        chinese_kept = len([w for w in filtered_word_freqs if len(w) == 1 and is_chinese_char(w)])
-        print(f"✅ 词频计算完成! {len(filtered_word_freqs):,}词汇 (中文:{chinese_kept:,}) 耗时:{elapsed:.1f}秒")
-    
-    def initialize_splits(self):
+        chinese_kept = len(
+            [w for w in filtered_word_freqs if len(w) == 1 and is_chinese_char(w)]
+        )
+        print(
+            f"✅ 词频计算完成! {len(filtered_word_freqs):,}词汇 (中文:{chinese_kept:,}/原始:{original_vocab_size:,}) 耗时:{elapsed:.1f}秒"
+        )
+
+    def initialize_splits(self) -> None:
         """初始化分割：将每个词分割成字符"""
-        splits = {}
+
+        splits: Dict[str, List[str]] = {}
         for word in self.word_freqs:
-            # 对中文字符，不需要进一步分割
             if len(word) == 1 and is_chinese_char(word):
-                splits[word] = [word, '</w>']
+                splits[word] = [word, "</w>"]
             else:
-                # 对其他词，分割成字符
-                splits[word] = [c for c in word] + ['</w>']
+                splits[word] = [c for c in word] + ["</w>"]
         self.splits = splits
         print(f"✅ 初始化分割完成! {len(splits):,}个词")
-    
+
     def compute_pair_frequencies(self) -> Dict[Tuple[str, str], int]:
         """计算相邻字符对的频率"""
+
         pair_freqs = defaultdict(int)
-        
         for word, freq in self.word_freqs.items():
             split = self.splits[word]
-            
-            # 计算相邻字符对
             for i in range(len(split) - 1):
                 pair = (split[i], split[i + 1])
                 pair_freqs[pair] += freq
-        
         return dict(pair_freqs)
-    
-    def merge_vocab(self, pair: Tuple[str, str]):
+
+    def merge_vocab(self, pair: Tuple[str, str]) -> int:
         """合并词汇表中的字符对"""
-        new_splits = {}
-        merge_count = 0  # 统计实际合并次数
-        
+
+        new_splits: Dict[str, List[str]] = {}
+        merge_count = 0
         for word in self.word_freqs:
             split = self.splits[word]
-            new_split = []
+            new_split: List[str] = []
             i = 0
-            
             while i < len(split):
-                # 查找要合并的字符对
                 if i < len(split) - 1 and (split[i], split[i + 1]) == pair:
-                    # 合并字符对
                     new_split.append(split[i] + split[i + 1])
                     merge_count += 1
                     i += 2
                 else:
                     new_split.append(split[i])
                     i += 1
-            
             new_splits[word] = new_split
-        
         self.splits = new_splits
-        return merge_count  # 返回实际合并次数
-    
-    def train(self, texts: List[str]):
+        return merge_count
+
+    def train(self, texts: List[str]) -> None:
         """训练BPE分词器"""
+
         print("🚀 开始训练BPE分词器（中文优化版）...")
-        
-        # 检查数据量并进行采样
         original_count = len(texts)
-        max_texts = 150000  # 增加最大文本数量限制
-        
+        max_texts = 150000
         if original_count > max_texts:
             print(f"⚠️  数据量过大({original_count:,})，采样到{max_texts:,}条")
-            random.seed(42)  # 固定随机种子确保可重现
+            random.seed(42)
             texts = random.sample(texts, max_texts)
-        
+
         total_start_time = time.time()
-        
-        # 步骤1：计算词频
         self.compute_word_frequencies(texts)
-        
-        # 步骤2：初始化分割
         self.initialize_splits()
-        
-        # 步骤3：迭代合并
-        merges = {}
-        vocab_size = self.vocab_size - 4  # 减去4个特殊token
-        
+
+        merges: Dict[Tuple[str, str], int] = {}
+        vocab_target = self.vocab_size - self._reserved_token_count
+        if vocab_target <= 0:
+            raise ValueError(
+                f"vocab_size={self.vocab_size} 太小，至少需要 {self._reserved_token_count + 1} 以容纳特殊token和byte fallback。"
+            )
+
         chinese_words = len([w for w in self.word_freqs if len(w) == 1 and is_chinese_char(w)])
-        print(f"🔄 开始BPE训练: 目标{vocab_size:,}次合并, {len(self.word_freqs):,}词汇(中文:{chinese_words:,})")
-        
+        print(
+            f"🔄 开始BPE训练: 目标{vocab_target:,}次合并, {len(self.word_freqs):,}词汇(中文:{chinese_words:,})"
+        )
+
         merge_start_time = time.time()
-        last_best_pair = None  # 上一次最佳字符对
-        repeated_pair_count = 0  # 相同字符对重复次数
-        no_progress_count = 0  # 无进展次数（没有实际合并）
-        
-        for i in range(vocab_size):
-            # 计算字符对频率
+        last_best_pair = None
+        repeated_pair_count = 0
+        no_progress_count = 0
+
+        for i in range(vocab_target):
             pair_freqs = self.compute_pair_frequencies()
-            
             if not pair_freqs:
                 print(f"\n⚠️  没有更多的字符对可以合并，提前结束于第 {i + 1} 次合并")
                 break
-            
-            # 找到频率最高的字符对
+
             best_pair = max(pair_freqs, key=pair_freqs.get)
             best_freq = pair_freqs[best_pair]
-            
-            # 死循环检测逻辑
+
             if best_pair == last_best_pair:
                 repeated_pair_count += 1
-                if repeated_pair_count >= 3:  # 连续3次相同字符对
+                if repeated_pair_count >= 3:
                     break
             else:
                 repeated_pair_count = 0
-            
+
             if best_pair in merges:
                 no_progress_count += 1
                 if no_progress_count >= 10:
@@ -272,11 +425,8 @@ class BPETokenizer:
                 continue
             else:
                 no_progress_count = 0
-            
-            # 合并最频繁的字符对
+
             merge_count = self.merge_vocab(best_pair)
-            
-            # 如果没有实际合并任何内容，跳过
             if merge_count == 0:
                 no_progress_count += 1
                 if no_progress_count >= 10:
@@ -284,66 +434,75 @@ class BPETokenizer:
                 continue
             else:
                 no_progress_count = 0
-            
-            # 记录合并规则
+
             merges[best_pair] = i
             last_best_pair = best_pair
-            
-            # 显示进度（每100次或重要节点）
-            if (i + 1) % 100 == 0 or i == vocab_size - 1:
-                show_progress_with_stats(i + 1, vocab_size, merge_start_time, 
-                                       prefix='BPE训练', 
-                                       extra_info=f"最新: '{best_pair[0]}'+'{best_pair[1]}'({best_freq:,})")
-        
+
+            if (i + 1) % 100 == 0 or i == vocab_target - 1:
+                show_progress_with_stats(
+                    i + 1,
+                    vocab_target,
+                    merge_start_time,
+                    prefix="BPE训练",
+                    extra_info=f"最新: '{best_pair[0]}'+'{best_pair[1]}'({best_freq:,})",
+                )
+
         self.merges = merges
-        
         merge_elapsed = time.time() - merge_start_time
         print(f"\n✅ BPE合并完成！实际合并次数: {len(merges):,} (耗时: {merge_elapsed:.2f}秒)")
-        
-        # 构建词汇表
+
         self.build_vocab()
-        
         total_elapsed = time.time() - total_start_time
-        
-        # 统计中文字符覆盖率（包括带</w>的token）
-        chinese_tokens = len([token for token in self.vocab 
-                            if (len(token) == 1 and is_chinese_char(token)) or 
-                               (token.endswith('</w>') and len(token) == 5 and is_chinese_char(token[0]))])
-        
-        print(f"🎉 训练完成! 词汇表:{len(self.vocab):,} 中文:{chinese_tokens:,} 总耗时:{total_elapsed:.1f}秒")
-    
-    def build_vocab(self):
+        chinese_tokens = len(
+            [
+                token
+                for token in self.vocab
+                if (len(token) == 1 and is_chinese_char(token))
+                or (token.endswith("</w>") and len(token) > 4 and is_chinese_char(token[0]))
+            ]
+        )
+        fallback_state = "启用" if self.enable_byte_fallback else "关闭"
+        print(
+            f"🎉 训练完成! 词汇表:{len(self.vocab):,} 中文:{chinese_tokens:,} ByteFallback:{fallback_state} 总耗时:{total_elapsed:.1f}秒"
+        )
+
+    def build_vocab(self) -> None:
         """构建词汇表"""
-        vocab = {}
-        
-        # 添加特殊token
+
+        vocab: Dict[str, int] = {}
         vocab[self.pad_token] = self.pad_id
         vocab[self.unk_token] = self.unk_id
         vocab[self.bos_token] = self.bos_id
         vocab[self.eos_token] = self.eos_id
-        
-        # 添加所有子词
+
+        if self.enable_byte_fallback:
+            for byte in range(256):
+                token = self._format_byte_token(byte)
+                if token not in vocab:
+                    vocab[token] = len(vocab)
+            vocab[self.byte_eow_token] = len(vocab)
+
         for word in self.word_freqs:
             for token in self.splits[word]:
                 if token not in vocab:
                     vocab[token] = len(vocab)
-        
+
         self.vocab = vocab
-    
+        self.vocab_size = len(vocab)
+        self._sync_internal_state()
+        self._validate_special_tokens(require_presence=True)
+        self._update_checksum()
+
     def encode_word(self, word: str) -> List[str]:
         """编码单个词"""
-        # 检查是否是单个中文字符，直接返回带</w>的版本
+
         if len(word) == 1 and is_chinese_char(word):
-            return [word + '</w>']
-        
-        # 初始化为字符列表
-        tokens = [c for c in word] + ['</w>']
-        
-        # 应用所有合并规则
-        for pair, merge_order in sorted(self.merges.items(), key=lambda x: x[1]):
-            new_tokens = []
+            return [word + "</w>"]
+
+        tokens = [c for c in word] + ["</w>"]
+        for pair, _ in sorted(self.merges.items(), key=lambda x: x[1]):
+            new_tokens: List[str] = []
             i = 0
-            
             while i < len(tokens):
                 if i < len(tokens) - 1 and (tokens[i], tokens[i + 1]) == pair:
                     new_tokens.append(tokens[i] + tokens[i + 1])
@@ -351,145 +510,309 @@ class BPETokenizer:
                 else:
                     new_tokens.append(tokens[i])
                     i += 1
-            
             tokens = new_tokens
-        
         return tokens
-    
+
     def encode(self, text: str, add_special_tokens: bool = True) -> List[int]:
         """编码文本为token ID列表"""
-        # 预分词
+
         words = self.pre_tokenize(text)
-        
-        token_ids = []
-        
+        token_ids: List[int] = []
+
         if add_special_tokens:
             token_ids.append(self.bos_id)
-        
-        # 编码每个词
+
         for word in words:
             try:
                 tokens = self.encode_word(word)
-                for token in tokens:
-                    token_id = self.vocab.get(token, self.unk_id)
-                    token_ids.append(token_id)
-            except Exception as e:
-                # 出错时使用未知token
-                token_ids.append(self.unk_id)
-        
+            except Exception:
+                tokens = []
+
+            mapped_ids: List[int] = []
+            for token in tokens:
+                token_id = self.vocab.get(token)
+                if token_id is None:
+                    mapped_ids = []
+                    break
+                mapped_ids.append(token_id)
+
+            if not mapped_ids:
+                fallback_ids = self._encode_as_bytes(word)
+                token_ids.extend(fallback_ids)
+            else:
+                token_ids.extend(mapped_ids)
+
         if add_special_tokens:
             token_ids.append(self.eos_id)
-        
+
         return token_ids
-    
+
     def decode(self, token_ids: List[int]) -> str:
         """解码token ID列表为文本"""
-        # 创建ID到token的映射
-        id_to_token = {v: k for k, v in self.vocab.items()}
-        
-        tokens = []
+
+        if not token_ids:
+            return ""
+
+        id_to_token = self._id_to_token or {v: k for k, v in self.vocab.items()}
+        output: List[str] = []
+        byte_buffer: bytearray = bytearray()
+
+        def flush_byte_buffer() -> Optional[str]:
+            if not byte_buffer:
+                return None
+            try:
+                decoded = byte_buffer.decode("utf-8")
+            except UnicodeDecodeError:
+                decoded = byte_buffer.decode("latin-1")
+            byte_buffer.clear()
+            output.append(decoded)
+            if self._should_add_space(decoded):
+                output.append(" ")
+            return decoded
+
         for token_id in token_ids:
-            if token_id in id_to_token:
-                token = id_to_token[token_id]
-                # 跳过特殊token
-                if token not in [self.pad_token, self.bos_token, self.eos_token]:
-                    tokens.append(token)
-        
-        # 合并tokens并处理词结束标记
-        text = ''.join(tokens)
-        text = text.replace('</w>', ' ')
-        
-        return text.strip()
-    
-    def save(self, path: str):
+            token = id_to_token.get(token_id)
+            if token is None:
+                continue
+            if token in {self.pad_token, self.bos_token}:
+                continue
+            if token == self.eos_token:
+                flush_byte_buffer()
+                break
+
+            if self.enable_byte_fallback and token_id in self.id_to_byte:
+                byte_buffer.append(self.id_to_byte[token_id])
+                continue
+
+            if self.enable_byte_fallback and token == self.byte_eow_token:
+                flush_byte_buffer()
+                continue
+
+            flush_byte_buffer()
+
+            if token in {self.unk_token}:
+                continue
+
+            if token.endswith("</w>"):
+                surface = token[:-4]
+                output.append(surface)
+                if self._should_add_space(surface):
+                    output.append(" ")
+            else:
+                output.append(token)
+
+        flush_byte_buffer()
+
+        text = "".join(output)
+        return self._postprocess_text(text)
+
+    def save(self, path: str) -> None:
         """保存分词器"""
-        data = {
-            'vocab': self.vocab,
-            'merges': self.merges,
-            'vocab_size': self.vocab_size
+
+        self._validate_special_tokens(require_presence=True)
+        payload_without_checksum = {
+            "vocab": self.vocab,
+            "merges": self.merges,
+            "vocab_size": self.vocab_size,
+            "config": self.get_config(),
         }
-        
-        with open(path, 'wb') as f:
-            pickle.dump(data, f)
-        
+        checksum = hashlib.sha256(pickle.dumps(payload_without_checksum, protocol=4)).hexdigest()
+        payload_without_checksum["checksum"] = checksum
+
+        with open(path, "wb") as f:
+            pickle.dump(payload_without_checksum, f)
+
+        self._checksum = checksum
         print(f"分词器已保存到: {path}")
-    
-    def load(self, path: str):
+
+    def load(self, path: str) -> None:
         """加载分词器"""
-        with open(path, 'rb') as f:
+
+        with open(path, "rb") as f:
             data = pickle.load(f)
-        
-        self.vocab = data['vocab']
-        self.merges = data['merges']
-        self.vocab_size = data['vocab_size']
-        
+
+        expected_checksum = data.get("checksum")
+        payload_for_checksum = {k: data[k] for k in data if k != "checksum"}
+        if expected_checksum:
+            actual_checksum = hashlib.sha256(pickle.dumps(payload_for_checksum, protocol=4)).hexdigest()
+            if actual_checksum != expected_checksum:
+                raise ValueError("Tokenizer checksum mismatch，文件可能已损坏或被篡改。")
+            self._checksum = expected_checksum
+        else:
+            # 兼容旧版本
+            self._checksum = ""
+
+        self.vocab = data["vocab"]
+        self.merges = data.get("merges", {})
+        self.vocab_size = data.get("vocab_size", len(self.vocab))
+
+        config = data.get("config") or {}
+        self.lowercase = config.get("lowercase", True)
+        self.normalize_nfkc = config.get("normalize_nfkc", True)
+        self.strip_spaces = config.get("strip_spaces", True)
+        self.enable_byte_fallback = config.get("enable_byte_fallback", False)
+        self._update_reserved_token_count()
+
+        if self.enable_byte_fallback and self.byte_eow_token not in self.vocab:
+            # 旧分词器不包含字节token，自动禁用
+            self.enable_byte_fallback = False
+            self._update_reserved_token_count()
+
+        self._sync_internal_state()
+        expected_special = config.get("special_tokens") if config else None
+        if expected_special:
+            mismatches = self.diff_special_tokens(expected_special)
+            if mismatches:
+                raise ValueError(
+                    "Tokenizer special tokens mismatch: "
+                    + ", ".join(
+                        f"{name}: ckpt={exp} vs file={act}" for name, (exp, act) in mismatches.items()
+                    )
+                )
+        self._validate_special_tokens(require_presence=True)
+        if not self._checksum:
+            self._update_checksum()
+
         print(f"分词器已加载: {path}")
-    
+
     def get_vocab_size(self) -> int:
         """获取词汇表大小"""
+
         return len(self.vocab)
 
+    def get_config(self) -> Dict[str, Any]:
+        return {
+            "vocab_size": self.vocab_size,
+            "lowercase": self.lowercase,
+            "normalize_nfkc": self.normalize_nfkc,
+            "strip_spaces": self.strip_spaces,
+            "enable_byte_fallback": self.enable_byte_fallback,
+            "normalizer_signature": self._normalizer_signature(),
+            "special_tokens": self.special_tokens_map(require_presence=bool(self.vocab)),
+        }
 
-def train_tokenizer_from_data(data_path: str, vocab_size: int = 30000) -> BPETokenizer:  # 增加默认词汇表大小
+    def checksum(self) -> str:
+        return self._checksum
+
+    def special_tokens_map(self, *, require_presence: bool = True) -> Dict[str, Dict[str, Any]]:
+        self._validate_special_tokens(require_presence=require_presence, strict=require_presence)
+        mapping: Dict[str, Dict[str, Any]] = {}
+        for name, token, fallback_id in [
+            ("pad", self.pad_token, self.pad_id),
+            ("unk", self.unk_token, self.unk_id),
+            ("bos", self.bos_token, self.bos_id),
+            ("eos", self.eos_token, self.eos_id),
+        ]:
+            vocab_id = self.vocab.get(token)
+            mapping[name] = {
+                "token": token,
+                "id": vocab_id if vocab_id is not None else fallback_id,
+                "present": vocab_id is not None,
+            }
+        if self.enable_byte_fallback:
+            vocab_id = self.vocab.get(self.byte_eow_token)
+            mapping["byte_eow"] = {
+                "token": self.byte_eow_token,
+                "id": vocab_id if vocab_id is not None else self.byte_eow_id,
+                "present": vocab_id is not None,
+            }
+        return mapping
+
+    def diff_special_tokens(self, expected: Dict[str, Dict[str, Any]]) -> Dict[str, tuple[Any, Any]]:
+        if not expected:
+            return {}
+        actual = self.special_tokens_map(require_presence=False)
+        mismatches: Dict[str, tuple[Any, Any]] = {}
+        for name, expected_info in expected.items():
+            actual_info = actual.get(name)
+            if actual_info is None:
+                mismatches[name] = (expected_info, None)
+                continue
+            keys_to_compare = {
+                key for key in ("token", "id", "present") if key in expected_info
+            }
+            if not keys_to_compare:
+                keys_to_compare = {"token", "id"}
+            comparison = {k: expected_info.get(k) for k in keys_to_compare}
+            actual_comp = {k: actual_info.get(k) for k in keys_to_compare}
+            if comparison != actual_comp:
+                mismatches[name] = (expected_info, actual_info)
+        return mismatches
+
+    def compute_unk_statistics(
+        self, texts: Iterable[str], sample_size: int = 1000
+    ) -> Dict[str, Any]:
+        total_tokens = 0
+        unk_tokens = 0
+        sampled = 0
+        for text in texts:
+            if sample_size and sampled >= sample_size:
+                break
+            sampled += 1
+            token_ids = self.encode(text, add_special_tokens=False)
+            total_tokens += len(token_ids)
+            unk_tokens += sum(1 for tid in token_ids if tid == self.unk_id)
+        unk_rate = (unk_tokens / total_tokens) if total_tokens else 0.0
+        return {
+            "sampled_texts": sampled,
+            "total_tokens": total_tokens,
+            "unk_tokens": unk_tokens,
+            "unk_rate": unk_rate,
+        }
+
+    def compute_unk_rate(self, texts: Iterable[str], sample_size: int = 1000) -> float:
+        return self.compute_unk_statistics(texts, sample_size)["unk_rate"]
+
+
+def train_tokenizer_from_data(data_path: str, vocab_size: int = 30000) -> BPETokenizer:
     """从数据文件训练分词器"""
+
     print(f"📁 加载数据: {data_path}, 目标词汇表: {vocab_size:,}")
-    
-    texts = []
+
+    texts: List[str] = []
     start_time = time.time()
-    line_count = 0
-    valid_count = 0
-    
-    with open(data_path, 'r', encoding='utf-8') as f:
+    with open(data_path, "r", encoding="utf-8") as f:
         for line in f:
-            line_count += 1
             line = line.strip()
-            if line:
-                try:
-                    data = json.loads(line)
-                    if 'conversations' in data:
-                        for conv in data['conversations']:
-                            texts.append(conv['content'])
-                            valid_count += 1
-                    elif 'text' in data:
-                        texts.append(data['text'])
-                        valid_count += 1
-                except json.JSONDecodeError:
-                    continue
-    
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if "conversations" in data:
+                for conv in data["conversations"]:
+                    texts.append(conv["content"])
+            elif "text" in data:
+                texts.append(data["text"])
+
     elapsed = time.time() - start_time
-    
-    # 统计中文字符
     chinese_char_count = sum(len([c for c in text if is_chinese_char(c)]) for text in texts)
     total_char_count = sum(len(text) for text in texts)
     chinese_ratio = chinese_char_count / total_char_count if total_char_count > 0 else 0
-    
+
     print(f"✅ 读取 {len(texts):,} 条文本，中文占比 {chinese_ratio:.1%} (耗时: {elapsed:.2f}秒)")
-    
-    # 训练分词器
+
     tokenizer = BPETokenizer(vocab_size=vocab_size)
     tokenizer.train(texts)
-    
     return tokenizer
 
 
 if __name__ == "__main__":
-    # 测试分词器
     sample_texts = [
         "Hello world! How are you?",
         "I am learning about BPE tokenization.",
         "This is a sample text for training.",
-        "BPE stands for Byte Pair Encoding."
+        "BPE stands for Byte Pair Encoding.",
     ]
-    
-    # 训练分词器
+
     tokenizer = BPETokenizer(vocab_size=1000)
     tokenizer.train(sample_texts)
-    
-    # 测试编码和解码
+
     test_text = "Hello! How are you doing?"
     token_ids = tokenizer.encode(test_text)
     decoded_text = tokenizer.decode(token_ids)
-    
+
     print(f"原文: {test_text}")
     print(f"编码: {token_ids}")
     print(f"解码: {decoded_text}")


### PR DESCRIPTION
## Summary
- add a normalizer signature, strict special-token validation, and diff helpers to the custom BPE tokenizer so parity checks catch id or normalization drift
- persist the tokenizer's special-token map inside checkpoints and assert it on load and during inference to guarantee training/inference artifacts stay aligned
- enhance the tokenizer diagnostics CLI with optional checkpoint comparison and richer metadata output for UNK investigations

## Testing
- python -m compileall src/tokenizer/bpe_tokenizer.py scripts/generate.py scripts/tokenizer_diagnostics.py src/training/pipeline/checkpointing.py

------
https://chatgpt.com/codex/tasks/task_e_68e7e2ffdaa08330ac0e1975e88524f6