### PR TITLE
Fix lint warnings in dataset tooling

### DIFF
--- a/scripts/clean_datasets.py
+++ b/scripts/clean_datasets.py
@@ -31,7 +31,7 @@ import json
 import os
 import re
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
+from typing import Any
 
 PLACEHOLDER_PATTERNS = [
     "……",  # Chinese ellipsis
@@ -74,7 +74,7 @@ class CleanConfig:
     drop_followups: bool = False
     strip_think: bool = False
     lowercase_signature: bool = False
-    max_refusal_count: Optional[int] = None
+    max_refusal_count: int | None = None
 
 
 @dataclass
@@ -87,7 +87,7 @@ class Stats:
     refusal_drops: int = 0
     think_stripped: int = 0
 
-    def as_dict(self) -> Dict[str, int]:
+    def as_dict(self) -> dict[str, int]:
         return {
             "total": self.total,
             "written": self.written,
@@ -176,19 +176,23 @@ def strip_think_blocks(text: str, stats: Stats) -> str:
     return new_text.strip()
 
 
-def load_json(line: str) -> Dict:
+def load_json(line: str) -> dict[str, Any]:
     return json.loads(line)
 
 
-def dump_json(obj: Dict) -> str:
+def dump_json(obj: dict[str, Any]) -> str:
     return json.dumps(obj, ensure_ascii=False, separators=(",", ":"))
 
 
-def clean_sft_entry(entry: Dict, cfg: CleanConfig, stats: Stats) -> Tuple[Optional[Dict], Optional[bytes]]:
+def clean_sft_entry(
+    entry: dict[str, Any],
+    cfg: CleanConfig,
+    stats: Stats,
+) -> tuple[dict[str, Any] | None, bytes | None]:
     convs = entry.get("conversations")
     if not isinstance(convs, list):
         return None, None
-    cleaned_convs: List[Dict[str, str]] = []
+    cleaned_convs: list[dict[str, str]] = []
     for turn in convs:
         role = turn.get("role")
         content = turn.get("content", "")
@@ -209,7 +213,7 @@ def clean_sft_entry(entry: Dict, cfg: CleanConfig, stats: Stats) -> Tuple[Option
         cleaned_convs.append({"role": role, "content": content})
     entry = {"conversations": cleaned_convs}
 
-    signature = None
+    signature: bytes | None = None
     if cfg.dedupe:
         signature = normalize_signature(
             dump_json(entry), lowercase=cfg.lowercase_signature
@@ -217,7 +221,11 @@ def clean_sft_entry(entry: Dict, cfg: CleanConfig, stats: Stats) -> Tuple[Option
     return entry, signature
 
 
-def clean_pretrain_entry(entry: Dict, cfg: CleanConfig, stats: Stats) -> Tuple[Optional[Dict], Optional[bytes]]:
+def clean_pretrain_entry(
+    entry: dict[str, Any],
+    cfg: CleanConfig,
+    stats: Stats,
+) -> tuple[dict[str, Any] | None, bytes | None]:
     text = entry.get("text")
     if not isinstance(text, str):
         return None, None
@@ -232,7 +240,7 @@ def clean_pretrain_entry(entry: Dict, cfg: CleanConfig, stats: Stats) -> Tuple[O
     if cfg.strip_think:
         text = strip_think_blocks(text, stats)
     entry = {"text": text}
-    signature = None
+    signature: bytes | None = None
     if cfg.dedupe:
         signature = normalize_signature(
             dump_json(entry), lowercase=cfg.lowercase_signature
@@ -263,7 +271,7 @@ def clean_file(args: argparse.Namespace) -> Stats:
 
     cleaner = clean_sft_entry if cfg.dataset_type == "sft" else clean_pretrain_entry
 
-    with open(args.input, "r", encoding="utf-8") as src, open(
+    with open(args.input, encoding="utf-8") as src, open(
         args.output, "w", encoding="utf-8"
     ) as dst:
         for line in src:

--- a/scripts/convert_to_jsonl.py
+++ b/scripts/convert_to_jsonl.py
@@ -13,18 +13,18 @@ Example:
 
 import argparse
 import json
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Generator, Optional
+from typing import Any
 
 
-def stream_json_array(path: Path) -> Generator[dict, None, None]:
+def stream_json_array(path: Path) -> Iterator[dict[str, Any]]:
     decoder = json.JSONDecoder()
     with path.open("r", encoding="utf-8") as f:
         buffer = ""
         chunk = f.read(65536)
         while chunk:
             buffer += chunk
-            idx = 0
             while True:
                 buffer = buffer.lstrip()
                 if not buffer:
@@ -54,7 +54,12 @@ def stream_json_array(path: Path) -> Generator[dict, None, None]:
                 yield obj
 
 
-def build_text(obj: dict, text_field: str, title_field: Optional[str], join_with: str) -> str:
+def build_text(
+    obj: dict[str, Any],
+    text_field: str,
+    title_field: str | None,
+    join_with: str,
+) -> str:
     pieces = []
     if title_field:
         title = obj.get(title_field)

--- a/scripts/dedupe_simhash.py
+++ b/scripts/dedupe_simhash.py
@@ -31,8 +31,8 @@ import hashlib
 import json
 import pickle
 from collections import defaultdict
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Dict, Iterable, List, Tuple
 
 
 def parse_args() -> argparse.Namespace:
@@ -50,7 +50,7 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def tokenize(text: str) -> Iterable[str]:
+def tokenize(text: str) -> list[str]:
     """Generate features for SimHash.
 
     Uses a mix of character bigrams/trigrams and whitespace tokens to better
@@ -58,7 +58,7 @@ def tokenize(text: str) -> Iterable[str]:
     """
     if not text:
         return []
-    features: List[str] = []
+    features: list[str] = []
     length = len(text)
     max_features = 32
     stride = max(1, length // max_features)
@@ -126,12 +126,12 @@ def band_keys(fp: int, bands: int, bits_per_band: int) -> Iterable[int]:
         yield (fp >> shift) & mask
 
 
-def dedupe(args: argparse.Namespace) -> Tuple[int, int, int]:
+def dedupe(args: argparse.Namespace) -> tuple[int, int, int]:
     ensure_config(args.bands, args.bits_per_band)
     args.output.parent.mkdir(parents=True, exist_ok=True)
 
     # bucket -> list of fingerprints
-    band_maps: List[Dict[int, List[int]]] = [defaultdict(list) for _ in range(args.bands)]
+    band_maps: list[dict[int, list[int]]] = [defaultdict(list) for _ in range(args.bands)]
     if args.state and args.state.exists():
         with args.state.open("rb") as state_file:
             saved = pickle.load(state_file)

--- a/scripts/prepare_training_data.py
+++ b/scripts/prepare_training_data.py
@@ -19,13 +19,11 @@ import concurrent.futures
 import hashlib
 import json
 import multiprocessing
-import os
 import shutil
 import subprocess
-import sys
 import tempfile
+from collections.abc import Iterable, Sequence
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
 try:
     import requests
@@ -41,12 +39,12 @@ def feature_hash(feature: str) -> int:
     return int.from_bytes(digest[:8], "big", signed=False)
 
 
-def tokenize_for_simhash(text: str, max_features: int = 32) -> List[str]:
+def tokenize_for_simhash(text: str, max_features: int = 32) -> list[str]:
     length = len(text)
     if not text or length < 2:
         return []
     stride = max(1, length // (max_features * 2))
-    feats: List[str] = []
+    feats: list[str] = []
     for n in (2, 3):
         for i in range(0, length - n + 1, stride):
             feats.append(text[i : i + n])
@@ -105,10 +103,10 @@ def simhash_dedupe(
     hamming_threshold: int = 3,
     max_bucket_size: int = 64,
     min_length: int = 10,
-) -> Tuple[int, int]:
+) -> tuple[int, int]:
     """Stream multiple JSONL files and remove near duplicates."""
     ensure_config(bands, bits_per_band)
-    band_maps: List[Dict[int, List[int]]] = [dict() for _ in range(bands)]
+    band_maps: list[dict[int, list[int]]] = [{} for _ in range(bands)]
     kept = 0
     dropped = 0
     output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -155,7 +153,13 @@ def simhash_dedupe(
 # JSONL conversion utilities
 # ---------------------------------------------------------------------------
 
-def convert_json_array_to_jsonl(input_path: Path, output_path: Path, text_field: str = "text", title_field: Optional[str] = "title", join_with: str = "\n\n") -> None:
+def convert_json_array_to_jsonl(
+    input_path: Path,
+    output_path: Path,
+    text_field: str = "text",
+    title_field: str | None = "title",
+    join_with: str = "\n\n",
+) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     decoder = json.JSONDecoder()
     buffer = ""
@@ -229,7 +233,7 @@ def download_file(url: str, dest: Path, force: bool = False) -> None:
     tmp_path.replace(dest)
 
 
-def parallel_download(urls: Sequence[Tuple[str, Path]], workers: int, force: bool = False) -> None:
+def parallel_download(urls: Sequence[tuple[str, Path]], workers: int, force: bool = False) -> None:
     with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
         futures = [executor.submit(download_file, url, path, force) for url, path in urls]
         for fut in concurrent.futures.as_completed(futures):
@@ -286,7 +290,7 @@ def prepare_wiki(download_dir: Path, tmp_dir: Path, final_dir: Path, workers: in
     urls = [(url, download_dir / fname) for fname, url in WIKI_PARTS]
     parallel_download(urls, workers=download_workers, force=force)
 
-    converted_paths: List[Path] = []
+    converted_paths: list[Path] = []
     with concurrent.futures.ProcessPoolExecutor(max_workers=workers) as executor:
         futures = []
         for fname, _ in WIKI_PARTS:
@@ -318,7 +322,7 @@ def prepare_chinacorpus(download_dir: Path, tmp_dir: Path, final_dir: Path, work
     urls = [(url, download_dir / fname) for fname, url in CHINACORPUS_PARTS]
     parallel_download(urls, workers=download_workers, force=force)
 
-    converted: List[Path] = []
+    converted: list[Path] = []
     with concurrent.futures.ProcessPoolExecutor(max_workers=workers) as executor:
         futures = []
         for fname, _ in CHINACORPUS_PARTS:
@@ -350,7 +354,7 @@ def prepare_slimpajama(download_dir: Path, tmp_dir: Path, final_dir: Path, worke
     urls = [(url, download_dir / fname) for fname, url in SLIMPAJAMA_FILES]
     parallel_download(urls, workers=download_workers, force=force)
 
-    decompressed: List[Path] = []
+    decompressed: list[Path] = []
     with concurrent.futures.ProcessPoolExecutor(max_workers=workers) as executor:
         futures = []
         for fname, _ in SLIMPAJAMA_FILES:
@@ -386,7 +390,13 @@ def clean_existing_jsonl(input_path: Path, output_path: Path, force: bool) -> Pa
     return output_path
 
 
-def write_manifests(final_dir: Path, pretrain_paths: Dict[str, Path], token_targets: Dict[str, float], configs_dir: Path, sft_path: Path) -> None:
+def write_manifests(
+    final_dir: Path,
+    pretrain_paths: dict[str, Path],
+    token_targets: dict[str, float],
+    configs_dir: Path,
+    sft_path: Path,
+) -> None:
     total = sum(token_targets.values())
     datasets = []
     for name, path in pretrain_paths.items():

--- a/scripts/train_sentencepiece.py
+++ b/scripts/train_sentencepiece.py
@@ -21,8 +21,8 @@ from __future__ import annotations
 import argparse
 import json
 import tempfile
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 
 try:
     import sentencepiece as spm

--- a/src/training/pipeline/data_manager.py
+++ b/src/training/pipeline/data_manager.py
@@ -64,7 +64,7 @@ class DataResolver:
             return None
 
         try:
-            with open(manifest_path, "r", encoding="utf-8") as handle:
+            with open(manifest_path, encoding="utf-8") as handle:
                 data = json.load(handle)
         except (OSError, json.JSONDecodeError) as exc:
             print(f"⚠️  读取 manifest 失败 {manifest_path}: {exc}")


### PR DESCRIPTION
## Summary
- modernize the dataset cleaning and conversion helpers to rely on built-in generics and explicit optional unions so they satisfy Ruff's UP series rules
- update the larger data preparation pipeline to import protocols from `collections.abc`, drop deprecated typing aliases, and tidy comprehension targets and download helpers
- adjust ancillary utilities—including the SentencePiece trainer and data manager—to follow the same import patterns and remove redundant file mode arguments flagged by lint

## Testing
- uv run ruff check src/ scripts/

------
https://chatgpt.com/codex/tasks/task_e_68ef08fa4ef083309413e80a58129ef2