### PR TITLE
fix: stabilize parallel pretokenization

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ mini-llm/
    > `--config medium`：载入中等规模的 `BaseConfig` 派生体，决定模型宽深、批量大小以及优化器超参。【F:config/training_config.py†L355-L413】
    > `--auto-resume`：触发自动检查点恢复逻辑，便于因中断而续训。【F:src/training/pipeline/cli.py†L88-L119】
 
+   **想要快速体验？** 项目提供 Makefile 快捷命令用于常见训练场景：
+
+   ```bash
+   make train-sft        # 使用 small 配置运行监督微调，会自动重训分词器
+   make train-pretrain   # 使用 medium 配置执行预训练流程
+   make train-dpo        # 依赖已完成的 SFT 权重，启动 DPO 训练
+   ```
+   > 这些命令封装了常见的训练参数组合，可在初次体验或演示场景下直接复用；若需更细粒度控制，可继续使用上方的 CLI 参数自定义运行。【F:Makefile†L73-L107】
+
 ### 命令行字段详解
 
 > `--mode {pretrain,sft,dpo,rlhf}`：控制训练阶段，内部 `apply_mode_defaults` 会针对不同目标调整最大步数、warmup 以及学习率。例如预训练保持 1e-4 学习率与 5% warmup，SFT 则降低学习率保护语言能力，RLHF 则进一步缩小步长以稳定 PPO。【F:src/training/pipeline/cli.py†L41-L82】

--- a/config/training_config.py
+++ b/config/training_config.py
@@ -201,6 +201,12 @@ class BaseConfig:
 
         # 数据预处理选项
         self.pretokenize_lm = os.environ.get("MINIGPT_PRETOKENIZE_LM", "1") == "1"
+        default_workers = min(16, os.cpu_count() or 1)
+        self.pretokenize_workers = int(
+            os.environ.get("MINIGPT_PRETOKENIZE_WORKERS", default_workers)
+        )
+        if self.pretokenize_workers < 1:
+            self.pretokenize_workers = 1
 
         # 训练后回归评估配置
         self.regression_eval_enabled = os.environ.get("MINIGPT_REGRESSION_EVAL", "1") == "1"

--- a/src/training/datasets/language_modeling.py
+++ b/src/training/datasets/language_modeling.py
@@ -2,12 +2,64 @@
 
 from __future__ import annotations
 
+import concurrent.futures
+import os
+import pickle
 import time
-from typing import Sequence
+from multiprocessing import get_context
+from typing import Any, Sequence
 
 import numpy as np
 import torch
 from torch.utils.data import Dataset
+
+
+_WORKER_TOKENIZER: Any | None = None
+_WORKER_MAX_LENGTH: int | None = None
+
+
+def _init_pretokenize_worker(tokenizer_bytes: bytes, max_length: int) -> None:
+    """Initialise worker local tokenizer state."""
+
+    global _WORKER_TOKENIZER, _WORKER_MAX_LENGTH
+    _WORKER_TOKENIZER = pickle.loads(tokenizer_bytes)
+    _WORKER_MAX_LENGTH = max_length
+
+
+def _worker_encode(index_and_text: tuple[int, str]) -> tuple[int, np.ndarray]:
+    """Encode text inside a worker process."""
+
+    global _WORKER_TOKENIZER, _WORKER_MAX_LENGTH
+    if _WORKER_TOKENIZER is None or _WORKER_MAX_LENGTH is None:
+        raise RuntimeError("预编码worker未正确初始化tokenizer状态")
+
+    idx, text = index_and_text
+    token_ids = _encode_with_tokenizer(_WORKER_TOKENIZER, text, _WORKER_MAX_LENGTH)
+    return idx, np.asarray(token_ids, dtype=np.int64)
+
+
+def _encode_with_tokenizer(tokenizer, text: str, max_length: int) -> list[int]:
+    """Encode text using the provided tokenizer and max length constraints."""
+
+    token_ids = tokenizer.encode(text, add_special_tokens=True)
+    if len(token_ids) < 2:
+        token_ids = [tokenizer.bos_id, tokenizer.eos_id]
+
+    if len(token_ids) > max_length:
+        token_ids = token_ids[:max_length]
+    else:
+        needed_padding = max(0, max_length - len(token_ids))
+        if needed_padding:
+            token_ids.extend([tokenizer.pad_id] * needed_padding)
+
+    if len(token_ids) < 2:
+        token_ids = [
+            tokenizer.bos_id,
+            tokenizer.eos_id,
+            *([tokenizer.pad_id] * max(0, max_length - 2)),
+        ]
+
+    return token_ids
 
 
 class LanguageModelingDataset(Dataset):
@@ -20,10 +72,12 @@ class LanguageModelingDataset(Dataset):
         max_length: int = 512,
         *,
         pretokenize: bool = True,
+        pretokenize_workers: int | None = None,
     ):
         self.tokenizer = tokenizer
         self.max_length = max_length
         self.pretokenize = pretokenize
+        self._explicit_worker_count = pretokenize_workers
 
         if pretokenize:
             self._tokens = self._pretokenize_texts(list(texts))
@@ -45,24 +99,71 @@ class LanguageModelingDataset(Dataset):
         return self._encode_to_tensor(self.texts[idx], idx)
 
     # ------------------------------------------------------------------
+    def _resolve_worker_count(self, total: int) -> int:
+        if total <= 1:
+            return 1
+
+        if self._explicit_worker_count is not None:
+            requested = max(1, self._explicit_worker_count)
+        else:
+            env_value = os.environ.get("MINIGPT_PRETOKENIZE_WORKERS")
+            if env_value is not None:
+                try:
+                    requested = max(1, int(env_value))
+                except ValueError:
+                    requested = 1
+            else:
+                requested = min(16, os.cpu_count() or 1)
+
+        return min(requested, total)
+
     def _pretokenize_texts(self, texts: list[str]) -> np.ndarray:
         total = len(texts)
         tokens = np.empty((total, self.max_length), dtype=np.int64)
         start_time = time.time()
 
-        print(f"  🔄 开始预编码 {total:,} 个样本...")
+        worker_count = self._resolve_worker_count(total)
+        print(
+            f"  🔄 开始预编码 {total:,} 个样本..."
+            + (f" (并行 {worker_count} workers)" if worker_count > 1 else "")
+        )
 
-        # 单线程编码（简单稳定，避免multiprocessing问题）
-        # tokenizer通常是C++实现，速度已经很快
-        for idx, text in enumerate(texts):
-            tokens[idx] = self._encode_numpy(text)
-
-            # 定期显示进度
-            if (idx + 1) % 5000 == 0 or idx == total - 1:
-                elapsed = time.time() - start_time
-                speed = (idx + 1) / elapsed if elapsed > 0 else 0.0
-                eta = (total - idx - 1) / speed if speed > 0 else 0
-                print(f"  🔄 预编码 {idx + 1:,}/{total:,} 样本 (速度 {speed:.1f}/s, 预计剩余 {eta/60:.1f}分钟)")
+        if worker_count <= 1:
+            self._pretokenize_texts_single(texts, tokens, start_time)
+        else:
+            try:
+                serialized_tokenizer = pickle.dumps(self.tokenizer)
+            except Exception as exc:  # pragma: no cover - defensive fallback
+                print(f"  ⚠️ 无法序列化tokenizer以进行并行预编码: {exc}，回退到单线程模式。")
+                self._pretokenize_texts_single(texts, tokens, start_time)
+            else:
+                mp_ctx = get_context("spawn")
+                with concurrent.futures.ProcessPoolExecutor(
+                    max_workers=worker_count,
+                    mp_context=mp_ctx,
+                    initializer=_init_pretokenize_worker,
+                    initargs=(serialized_tokenizer, self.max_length),
+                ) as executor:
+                    # ``executor.map`` streams results back in submission order without
+                    # building an unbounded future queue.  ``chunksize`` keeps each worker
+                    # busy while avoiding the enormous memory spike that ``submit``ing the
+                    # entire corpus at once would trigger when datasets contain millions of
+                    # samples.
+                    chunk_hint = max(1, min(64, total // max(worker_count, 1)))
+                    result_iter = executor.map(
+                        _worker_encode,
+                        enumerate(texts),
+                        chunksize=chunk_hint,
+                    )
+                    for completed, (idx, encoded) in enumerate(result_iter, start=1):
+                        tokens[idx] = encoded
+                        if completed % 5000 == 0 or completed == total:
+                            elapsed = time.time() - start_time
+                            speed = completed / elapsed if elapsed > 0 else 0.0
+                            eta = (total - completed) / speed if speed > 0 else 0
+                            print(
+                                f"  🔄 预编码 {completed:,}/{total:,} 样本 (速度 {speed:.1f}/s, 预计剩余 {eta/60:.1f}分钟)"
+                            )
 
         elapsed = time.time() - start_time
         avg_speed = total / elapsed if elapsed > 0 else 0.0
@@ -70,25 +171,23 @@ class LanguageModelingDataset(Dataset):
 
         return tokens
 
+    def _pretokenize_texts_single(
+        self, texts: list[str], tokens: np.ndarray, start_time: float
+    ) -> np.ndarray:
+        total = len(texts)
+        for idx, text in enumerate(texts):
+            tokens[idx] = self._encode_numpy(text)
+            if (idx + 1) % 5000 == 0 or idx == total - 1:
+                elapsed = time.time() - start_time
+                speed = (idx + 1) / elapsed if elapsed > 0 else 0.0
+                eta = (total - idx - 1) / speed if speed > 0 else 0
+                print(
+                    f"  🔄 预编码 {idx + 1:,}/{total:,} 样本 (速度 {speed:.1f}/s, 预计剩余 {eta/60:.1f}分钟)"
+                )
+        return tokens
+
     def _encode_numpy(self, text: str) -> np.ndarray:
-        token_ids = self.tokenizer.encode(text, add_special_tokens=True)
-        if len(token_ids) < 2:
-            token_ids = [self.tokenizer.bos_id, self.tokenizer.eos_id]
-
-        if len(token_ids) > self.max_length:
-            token_ids = token_ids[: self.max_length]
-        else:
-            needed_padding = max(0, self.max_length - len(token_ids))
-            if needed_padding:
-                token_ids.extend([self.tokenizer.pad_id] * needed_padding)
-
-        if len(token_ids) < 2:
-            token_ids = [
-                self.tokenizer.bos_id,
-                self.tokenizer.eos_id,
-                *([self.tokenizer.pad_id] * max(0, self.max_length - 2)),
-            ]
-
+        token_ids = _encode_with_tokenizer(self.tokenizer, text, self.max_length)
         return np.asarray(token_ids, dtype=np.int64)
 
     def _encode_to_tensor(self, text: str, idx: int) -> torch.Tensor:

--- a/src/training/pipeline/data_manager.py
+++ b/src/training/pipeline/data_manager.py
@@ -367,6 +367,7 @@ class DatasetPreparer:
             tokenizer=self.tokenizer,
             max_length=self.config.max_seq_len,
             pretokenize=getattr(self.config, "pretokenize_lm", True),
+            pretokenize_workers=getattr(self.config, "pretokenize_workers", None),
         )
 
     def _create_sft_dataset(self, data: Iterable[Any], augmentation=None):
@@ -392,6 +393,7 @@ class DatasetPreparer:
             texts=texts,
             tokenizer=self.tokenizer,
             max_length=self.config.max_seq_len,
+            pretokenize_workers=getattr(self.config, "pretokenize_workers", None),
         )
 
     @staticmethod

--- a/tests/test_language_modeling_dataset.py
+++ b/tests/test_language_modeling_dataset.py
@@ -1,0 +1,71 @@
+"""Tests for LanguageModelingDataset pretokenization parallelism."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+try:  # pragma: no cover - dependency guard for minimal environments
+    import torch  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover - skip when torch absent
+    import pytest
+
+    pytest.skip("torch is required for dataset tests", allow_module_level=True)
+
+from src.tokenizer.bpe_tokenizer import BPETokenizer
+from src.training.datasets.language_modeling import LanguageModelingDataset
+
+
+def _build_tokenizer() -> BPETokenizer:
+    tokenizer = BPETokenizer(vocab_size=256)
+    corpus = [
+        "你好，世界！",
+        "Mini-LLM 让教学更简单。",
+        "并行预编码应该与串行结果一致。",
+        "PyTorch 数据加载测试",
+    ]
+    tokenizer.train(corpus)
+    return tokenizer
+
+
+def test_parallel_pretokenize_matches_serial() -> None:
+    texts = [
+        "欢迎使用 Mini-LLM",  # ensure typical unicode
+        "并行进度需要保持稳定",
+        "数据预处理验证",
+        "第四条测试样本",
+        "更多的测试数据",
+        "第六条数据",
+        "第七条数据",
+        "第八条数据",
+    ]
+
+    tokenizer_parallel = _build_tokenizer()
+    tokenizer_serial = _build_tokenizer()
+
+    parallel_dataset = LanguageModelingDataset(
+        texts=texts,
+        tokenizer=tokenizer_parallel,
+        max_length=32,
+        pretokenize=True,
+        pretokenize_workers=4,
+    )
+
+    serial_dataset = LanguageModelingDataset(
+        texts=texts,
+        tokenizer=tokenizer_serial,
+        max_length=32,
+        pretokenize=True,
+        pretokenize_workers=1,
+    )
+
+    assert len(parallel_dataset) == len(serial_dataset)
+
+    for idx in range(len(parallel_dataset)):
+        parallel_item = parallel_dataset[idx].tolist()
+        serial_item = serial_dataset[idx].tolist()
+        assert parallel_item == serial_item


### PR DESCRIPTION
## Summary
- add a configurable pretokenization worker count to the base training config
- rework `LanguageModelingDataset` pretokenization to use spawn-safe worker pools, stream map results, and gracefully fall back to single-thread mode when necessary
- wire the dataset worker count through the data manager and add a regression test that compares parallel and serial tokenization outputs

## Testing
- uv run pytest tests/test_language_modeling_dataset.py
- PYTHONPATH=. uv run python /tmp/test_parallel_pretokenize.py

------
https://chatgpt.com/codex/tasks/task_e_68f1e45ede888330a5f740b5386a068e