### PR TITLE
Refine Qwen identity fine-tuning workflow

### DIFF
--- a/docs/qwen_identity_finetune.md
+++ b/docs/qwen_identity_finetune.md
@@ -1,0 +1,330 @@
+# Qwen 系列模型身份认同微调教程
+
+本文档介绍如何基于 Qwen3-1.7B 模型完成一次身份认同增强的微调流程。目标是在保持原有对话能力的同时，让模型在回答用户问题时展现新的身份设定。整体流程如下：准备环境 → 下载与清洗数据 → 预生成模型回复 → 构建身份认同增强数据集 → 配置并启动训练 → 观察与评估。
+
+## 1. 环境准备
+
+### 1.1 硬件与基础依赖
+
+- Python ≥ 3.8
+- 至少 1 张 NVIDIA/昇腾 GPU（建议显存 ≥ 32 GB）
+- PyTorch 与匹配的 CUDA 运行环境
+
+### 1.2 Python 依赖
+
+```bash
+pip install swanlab modelscope==1.22.0 "transformers>=4.50.0" datasets==3.2.0 accelerate pandas addict
+```
+
+> 本教程测试使用的版本：`modelscope==1.22.0`、`transformers==4.51.3`、`datasets==3.2.0`、`peft==0.11.1`、`accelerate==1.6.0`、`swanlab==0.5.7`。
+
+## 2. 数据准备
+
+### 2.1 下载原始医学数据集
+
+本案例使用 [delicate_medical_r1_data](https://modelscope.cn/datasets/krisfu/delicate_medical_r1_data) 数据集，适用于医疗问答场景。数据集字段包括 `Instruction`、`question`、`think`、`answer`、`metrics`。我们关注其中的 `question`、`think`、`answer` 字段。
+
+```python
+from modelscope.msdatasets import MsDataset
+import json
+import random
+
+random.seed(42)
+
+ds = MsDataset.load('krisfu/delicate_medical_r1_data', subset_name='default', split='train')
+data_list = list(ds)
+random.shuffle(data_list)
+
+split_idx = int(len(data_list) * 0.9)
+
+train_data = data_list[:split_idx]
+val_data = data_list[split_idx:]
+
+with open('train.jsonl', 'w', encoding='utf-8') as f:
+    for item in train_data:
+        json.dump(item, f, ensure_ascii=False)
+        f.write('\n')
+
+with open('val.jsonl', 'w', encoding='utf-8') as f:
+    for item in val_data:
+        json.dump(item, f, ensure_ascii=False)
+        f.write('\n')
+```
+
+### 2.2 构建身份认同增强数据
+
+我们的目标是让模型在回答问题时体现特定身份，例如“资深三甲医院内科主任”。直接在小规模数据集上全参训练可能导致过拟合。为缓解这一问题，先使用基础模型进行推理，生成一批未加入身份设定的参考答案，再与身份认同数据进行混合。
+
+#### 2.2.1 预生成模型回复
+
+```python
+from transformers import AutoTokenizer, AutoModelForCausalLM
+from datasets import Dataset
+import torch
+import random
+
+model_path = "./Qwen/Qwen3-1.7B"  # 后续会在第 3 节介绍如何下载
+
+tokenizer = AutoTokenizer.from_pretrained(model_path, use_fast=False, trust_remote_code=True)
+model = AutoModelForCausalLM.from_pretrained(model_path, device_map="auto", torch_dtype=torch.bfloat16)
+model.eval()
+
+PROMPT = "你是一位资深三甲医院内科主任，请以专业、耐心的语气回答患者问题。"
+
+raw_dataset = Dataset.from_json("train.jsonl")
+
+sample_ratio = 0.2
+sample_size = max(1, int(len(raw_dataset) * sample_ratio))
+selected_indices = random.sample(range(len(raw_dataset)), sample_size)
+
+identity_prompt = (
+    PROMPT
+    + "\n\nPersona Identity: 你是一位善于共情、用语温和的医学专家。"
+    + "请严格输出JSON，格式为 {\"think\": \"...\", \"answer\": \"...\"}."
+)
+
+inference_records = []
+for idx in selected_indices:
+    sample = raw_dataset[idx]
+    messages = [
+        {"role": "system", "content": identity_prompt},
+        {"role": "user", "content": sample["question"]}
+    ]
+    text = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+    inputs = tokenizer([text], return_tensors="pt").to(model.device)
+    with torch.no_grad():
+        outputs = model.generate(
+            **inputs,
+            max_new_tokens=512,
+            temperature=0.7,
+            top_p=0.95,
+            do_sample=True,
+        )
+    response = tokenizer.batch_decode(
+        outputs[:, inputs.input_ids.shape[-1]:], skip_special_tokens=True
+    )[0]
+    try:
+        payload = json.loads(response)
+        think = payload.get("think", "")
+        answer = payload.get("answer", "")
+    except json.JSONDecodeError:
+        think, answer = response.split("\n", 1) if "\n" in response else ("", response)
+    inference_records.append({
+        "question": sample["question"],
+        "think": think,
+        "answer": answer
+    })
+
+with open("identity_inference.jsonl", "w", encoding="utf-8") as f:
+    for record in inference_records:
+        json.dump(record, f, ensure_ascii=False)
+        f.write("\n")
+```
+
+上述脚本会生成 `identity_inference.jsonl` 文件，用于与原始数据混合。数量可根据资源调节，建议覆盖 10%~20% 的训练样本。
+
+#### 2.2.2 混合身份认同数据
+
+将推理生成的身份认同数据与原始数据进行合并，并保证 `think` 字段保留原始推理或空字符串，`answer` 字段使用带身份风格的输出。
+
+```python
+import json
+import random
+
+identity_ratio = 0.2
+
+with open("train.jsonl", "r", encoding="utf-8") as f:
+    base_records = [json.loads(line) for line in f]
+
+with open("identity_inference.jsonl", "r", encoding="utf-8") as f:
+    identity_records = [json.loads(line) for line in f]
+
+random.shuffle(identity_records)
+identity_map = {
+    record["question"]: record for record in identity_records[: int(len(base_records) * identity_ratio)]
+}
+
+mixed_records = []
+for record in base_records:
+    persona_record = identity_map.get(record["question"])
+    if persona_record:
+        updated = dict(record)
+        updated["answer"] = persona_record.get("answer", "")
+        if persona_record.get("think"):
+            updated["think"] = persona_record["think"]
+        mixed_records.append(updated)
+    else:
+        mixed_records.append(record)
+
+with open("train_mixed.jsonl", "w", encoding="utf-8") as f:
+    for record in mixed_records:
+        json.dump(record, f, ensure_ascii=False)
+        f.write("\n")
+```
+
+`train_mixed.jsonl` 便是包含身份认同强化后的训练集。若需要额外补充完全新建的身份问题，可以向 `identity_records` 中追加自定义问题，然后在上述流程中一起写入。验证集保持原始形式，便于评估身份设定对泛化能力的影响。
+
+## 3. 下载与加载 Qwen 模型
+
+```python
+from modelscope import snapshot_download
+from transformers import AutoModelForCausalLM, AutoTokenizer
+import torch
+
+model_dir = snapshot_download("Qwen/Qwen3-1.7B", cache_dir="./", revision="master")
+
+tokenizer = AutoTokenizer.from_pretrained(model_dir, use_fast=False, trust_remote_code=True)
+model = AutoModelForCausalLM.from_pretrained(model_dir, device_map="auto", torch_dtype=torch.bfloat16)
+model.enable_input_require_grads()
+```
+
+## 4. 数据格式转换与预处理
+
+我们将数据转换为 SFT 所需的 `instruction`/`input`/`output` 结构，并在 `output` 中显式区分 `think` 和 `answer`。
+
+```python
+PROMPT = "你是一位资深三甲医院内科主任，请根据患者问题给出带思考过程的回答。"
+MAX_LENGTH = 2048
+
+
+def dataset_jsonl_transfer(origin_path, new_path):
+    messages = []
+    with open(origin_path, "r", encoding="utf-8") as file:
+        for line in file:
+            data = json.loads(line)
+            output = f"<think>{data['think']}</think>\n{data['answer']}"
+            messages.append({
+                "instruction": PROMPT,
+                "input": data["question"],
+                "output": output
+            })
+    with open(new_path, "w", encoding="utf-8") as file:
+        for message in messages:
+            file.write(json.dumps(message, ensure_ascii=False) + "\n")
+
+
+def process_func(example):
+    instruction = tokenizer(
+        f"<|im_start|>system\n{PROMPT}<|im_end|>\n<|im_start|>user\n{example['input']}<|im_end|>\n<|im_start|>assistant\n",
+        add_special_tokens=False,
+    )
+    response = tokenizer(example["output"], add_special_tokens=False)
+    input_ids = instruction["input_ids"] + response["input_ids"] + [tokenizer.pad_token_id]
+    attention_mask = instruction["attention_mask"] + response["attention_mask"] + [1]
+    labels = [-100] * len(instruction["input_ids"]) + response["input_ids"] + [tokenizer.pad_token_id]
+    if len(input_ids) > MAX_LENGTH:
+        input_ids = input_ids[:MAX_LENGTH]
+        attention_mask = attention_mask[:MAX_LENGTH]
+        labels = labels[:MAX_LENGTH]
+    return {"input_ids": input_ids, "attention_mask": attention_mask, "labels": labels}
+```
+
+## 5. 训练配置与启动
+
+使用 Transformers 的 `Trainer` 进行全参微调，同时接入 SwanLab 追踪实验指标。
+
+```python
+import pandas as pd
+from datasets import Dataset
+from transformers import TrainingArguments, Trainer, DataCollatorForSeq2Seq
+import swanlab
+import os
+
+os.environ["SWANLAB_PROJECT"] = "qwen3-sft-medical-identity"
+
+train_path = "train_mixed.jsonl"
+val_path = "val.jsonl"
+
+train_format_path = "train_mixed_format.jsonl"
+val_format_path = "val_format.jsonl"
+
+for src, dst in [(train_path, train_format_path), (val_path, val_format_path)]:
+    if not os.path.exists(dst):
+        dataset_jsonl_transfer(src, dst)
+
+train_df = pd.read_json(train_format_path, lines=True)
+val_df = pd.read_json(val_format_path, lines=True)
+
+train_dataset = Dataset.from_pandas(train_df).map(process_func, remove_columns=train_df.columns)
+val_dataset = Dataset.from_pandas(val_df).map(process_func, remove_columns=val_df.columns)
+
+args = TrainingArguments(
+    output_dir="./output/Qwen3-1.7B-identity",
+    per_device_train_batch_size=1,
+    per_device_eval_batch_size=1,
+    gradient_accumulation_steps=4,
+    eval_strategy="steps",
+    eval_steps=100,
+    logging_steps=10,
+    num_train_epochs=1,
+    save_steps=400,
+    learning_rate=1e-4,
+    save_on_each_node=True,
+    gradient_checkpointing=True,
+    report_to="swanlab",
+    run_name="qwen3-1.7B-identity",
+)
+
+trainer = Trainer(
+    model=model,
+    args=args,
+    train_dataset=train_dataset,
+    eval_dataset=val_dataset,
+    data_collator=DataCollatorForSeq2Seq(tokenizer=tokenizer, padding=True),
+)
+
+trainer.train()
+```
+
+> 仅训练 1 个 epoch，避免在小数据集上过拟合。如需更长训练，可结合验证集损失和 SwanLab 可视化判断是否出现过拟合趋势。
+
+## 6. 推理与评估
+
+完成训练后，可选取若干条验证集样本验证身份设定效果。
+
+```python
+from swanlab import Text
+
+val_preview = val_df.head(3)
+preview_logs = []
+
+for _, row in val_preview.iterrows():
+    messages = [
+        {"role": "system", "content": row["instruction"]},
+        {"role": "user", "content": row["input"]},
+    ]
+    response = predict(messages, model, tokenizer)
+    preview_logs.append(Text(f"Question: {row['input']}\n\nLLM: {response}"))
+
+swanlab.log({"IdentityPreview": preview_logs})
+swanlab.finish()
+```
+
+## 7. 关键注意事项
+
+1. **身份认同混合策略**：预生成的回答用于“打底”，再混入显式身份数据，可引导模型稳定输出身份特征，同时降低仅凭少量身份数据直接训练的过拟合风险。
+2. **数据质量**：确保身份设定描述一致、逻辑连贯，避免冲突信息导致模型输出混乱。
+3. **训练监控**：关注 SwanLab 中的 `train_loss` 与 `eval_loss`，若验证损失上升，应考虑减少 epoch 或加入更多多样化样本。
+4. **安全合规**：医学场景需注意输出免责声明和就医建议的边界，避免误导用户。
+
+按照上述流程，即可完成一次针对 Qwen 系列模型的身份认同微调，并通过推理生成与数据混合策略缓解过拟合问题。
+
+## 8. 自动化脚本与示例代码
+
+文档中的所有步骤已经整理为仓库内的可复用代码：
+
+- `examples/qwen_identity_finetune/`：包含完整的 Python 管道实现，可直接在其他项目中导入使用。
+- `scripts/run_qwen_identity_finetune.py`：一键拉起数据准备 → 人格样本生成 → 数据混合 → 训练 → 评估的脚本。
+
+默认情况下，只需执行以下命令即可在本地启动全流程（会自动在 `./qwen_identity_workspace` 目录下产生日志与数据）：
+
+```bash
+python scripts/run_qwen_identity_finetune.py \
+  --persona-name "Dr. Grace" \
+  --persona-statement "你是一位善于共情、用语温和的医学专家，擅长通过先思考再回答的方式提供循序渐进的指导。" \
+  --identity-mix-ratio 0.25
+```
+
+脚本会自动对原始训练集中抽样一定比例的问题进行身份推理、混入并启动训练。若需要调整训练/验证划分比例，可使用 `--train-split-ratio` 指定。
+
+若需要额外注入全新的人格问答样本，可搭配 `--warmup-question`（可多次传入）、`--max-identity-samples` 等参数，为自动抽样之外的问题生成身份回复后追加到训练集。

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Example pipelines and utilities for persona-oriented fine-tuning."""

--- a/examples/qwen_identity_finetune/__init__.py
+++ b/examples/qwen_identity_finetune/__init__.py
@@ -1,0 +1,13 @@
+"""Persona identity fine-tuning utilities for Qwen models."""
+
+from .pipeline import (
+    IdentityFineTuneConfig,
+    PersonaSpecification,
+    run_identity_finetune_pipeline,
+)
+
+__all__ = [
+    "IdentityFineTuneConfig",
+    "PersonaSpecification",
+    "run_identity_finetune_pipeline",
+]

--- a/examples/qwen_identity_finetune/pipeline.py
+++ b/examples/qwen_identity_finetune/pipeline.py
@@ -1,0 +1,568 @@
+"""Utilities for fine-tuning Qwen models with persona-aligned identity data.
+
+This module provides a complete pipeline that mirrors the accompanying
+`docs/qwen_identity_finetune.md` tutorial.  It can download and prepare the
+Delicate Medical R1 dataset, generate additional persona-aligned samples via
+inference, mix them with the training data, and launch a supervised fine-tuning
+run that tracks metrics in SwanLab.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import pandas as pd
+import torch
+from datasets import Dataset
+from modelscope import MsDataset, snapshot_download
+from transformers import (
+    AutoTokenizer,
+    AutoModelForCausalLM,
+    DataCollatorForSeq2Seq,
+    Trainer,
+    TrainingArguments,
+)
+
+import swanlab
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class PersonaSpecification:
+    """Configuration for generating persona-aligned identity data."""
+
+    persona_name: str
+    identity_statement: str
+    mix_ratio: float = 0.2
+    max_identity_samples: Optional[int] = None
+    warmup_questions: Optional[Sequence[str]] = None
+
+
+@dataclass
+class IdentityFineTuneConfig:
+    """High level configuration for the identity fine-tuning pipeline."""
+
+    work_dir: str
+    persona: PersonaSpecification
+    dataset_name: str = "krisfu/delicate_medical_r1_data"
+    dataset_subset: str = "default"
+    dataset_split: str = "train"
+    seed: int = 42
+    prompt: str = (
+        "你是一个医学专家，你需要根据用户的问题，给出带有思考的回答。"
+    )
+    base_model_repo: str = "Qwen/Qwen3-1.7B"
+    base_model_revision: str = "master"
+    cache_dir: str = "./pretrained"
+    max_length: int = 2048
+    train_split_ratio: float = 0.9
+    per_device_batch_size: int = 1
+    per_device_eval_batch_size: int = 1
+    gradient_accumulation_steps: int = 4
+    train_epochs: int = 1
+    learning_rate: float = 1e-4
+    eval_steps: int = 100
+    logging_steps: int = 10
+    save_steps: int = 400
+    gradient_checkpointing: bool = True
+    run_name: str = "qwen3-identity"
+    output_subdir: str = "outputs"
+    identity_generation_temperature: float = 0.7
+    identity_generation_top_p: float = 0.95
+    predictions_to_log: int = 3
+
+    def __post_init__(self) -> None:
+        self.work_dir = os.path.abspath(self.work_dir)
+        self.output_dir = os.path.join(self.work_dir, self.output_subdir)
+        self.cache_dir = os.path.abspath(self.cache_dir)
+        if not 0 < self.train_split_ratio < 1:
+            raise ValueError("train_split_ratio must be between 0 and 1 (exclusive)")
+        if not 0 <= self.persona.mix_ratio <= 1:
+            raise ValueError("persona mix_ratio must be within [0, 1]")
+        if self.predictions_to_log < 0:
+            raise ValueError("predictions_to_log must be non-negative")
+
+
+def _ensure_directory(path: str | Path) -> None:
+    Path(path).mkdir(parents=True, exist_ok=True)
+
+
+def _set_seed(seed: int) -> None:
+    random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def _jsonl_dump(records: Iterable[Dict], path: str | Path) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        for record in records:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def _jsonl_load(path: str | Path) -> List[Dict]:
+    with open(path, "r", encoding="utf-8") as f:
+        return [json.loads(line) for line in f]
+
+
+def _download_dataset(config: IdentityFineTuneConfig) -> List[Dict[str, str]]:
+    LOGGER.info(
+        "Downloading dataset %s (subset=%s split=%s)",
+        config.dataset_name,
+        config.dataset_subset,
+        config.dataset_split,
+    )
+    dataset = MsDataset.load(
+        config.dataset_name,
+        subset_name=config.dataset_subset,
+        split=config.dataset_split,
+    )
+    return list(dataset)
+
+
+def _split_dataset(
+    data: Sequence[Dict[str, str]], split_ratio: float, seed: int
+) -> Tuple[List[Dict[str, str]], List[Dict[str, str]]]:
+    rng = random.Random(seed)
+    shuffled = list(data)
+    rng.shuffle(shuffled)
+    split_idx = int(len(shuffled) * split_ratio)
+    return shuffled[:split_idx], shuffled[split_idx:]
+
+
+def _parse_identity_response(text: str) -> Optional[Tuple[str, str]]:
+    cleaned = text.strip()
+    if not cleaned:
+        return None
+
+    if cleaned.startswith("{"):
+        try:
+            payload = json.loads(cleaned)
+            think = payload.get("think", "").strip()
+            answer = payload.get("answer", "").strip()
+            if think and answer:
+                return think, answer
+        except json.JSONDecodeError:
+            LOGGER.debug("Failed to parse JSON response: %s", cleaned)
+
+    if "<think>" in cleaned and "</think>" in cleaned:
+        start = cleaned.index("<think>") + len("<think>")
+        end = cleaned.index("</think>")
+        think = cleaned[start:end].strip()
+        answer = cleaned[end + len("</think>") :].strip()
+        if think and answer:
+            return think, answer
+
+    lines = cleaned.splitlines()
+    if len(lines) >= 2:
+        think = lines[0].strip()
+        answer = "\n".join(lines[1:]).strip()
+        if think and answer:
+            return think, answer
+    return None
+
+
+def _generate_identity_samples(
+    config: IdentityFineTuneConfig,
+    tokenizer: AutoTokenizer,
+    model: AutoModelForCausalLM,
+    base_records: Sequence[Dict[str, str]],
+) -> List[Dict[str, str]]:
+    persona = config.persona
+    if persona.mix_ratio <= 0:
+        LOGGER.info("Persona mix ratio <= 0. Skipping identity generation.")
+        return []
+
+    if not base_records:
+        LOGGER.warning("Base dataset is empty. No persona samples will be generated.")
+        return []
+
+    rng = random.Random(config.seed)
+    target_identity = max(1, int(len(base_records) * persona.mix_ratio))
+    if persona.max_identity_samples is not None:
+        target_identity = min(target_identity, persona.max_identity_samples)
+
+    candidate_indices = list(range(len(base_records)))
+    rng.shuffle(candidate_indices)
+    selected_indices = candidate_indices[:target_identity]
+
+    prompts: List[Tuple[str, Optional[int]]] = [
+        (base_records[idx]["question"], idx) for idx in selected_indices
+    ]
+
+    if persona.warmup_questions:
+        prompts.extend((question, None) for question in persona.warmup_questions)
+
+    LOGGER.info(
+        "Generating %d persona-aligned samples for persona '%s'",
+        len(prompts),
+        persona.persona_name,
+    )
+
+    identity_records: List[Dict[str, str]] = []
+    for question, source_index in prompts:
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    f"{config.prompt}\n\nPersona Identity: {persona.identity_statement}\n"
+                    "请严格输出JSON，格式为 {\"think\": \"...\", \"answer\": \"...\"}."
+                ),
+            },
+            {"role": "user", "content": question},
+        ]
+        chat_template = tokenizer.apply_chat_template(
+            messages,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        inputs = tokenizer([chat_template], return_tensors="pt")
+        device = model.device
+        inputs = {k: v.to(device) for k, v in inputs.items()}
+        with torch.no_grad():
+            generated = model.generate(
+                **inputs,
+                max_new_tokens=512,
+                temperature=config.identity_generation_temperature,
+                top_p=config.identity_generation_top_p,
+                do_sample=True,
+            )
+        generated_ids = generated[0][inputs["input_ids"].shape[-1] :]
+        response = tokenizer.decode(generated_ids, skip_special_tokens=True)
+        parsed = _parse_identity_response(response)
+        if not parsed:
+            LOGGER.warning("Skipping persona sample due to parse failure: %s", response)
+            continue
+        think, answer = parsed
+        record = {
+            "question": question,
+            "think": think,
+            "answer": answer,
+        }
+        if source_index is not None:
+            record["source_index"] = source_index
+        identity_records.append(record)
+
+    LOGGER.info("Generated %d persona-aligned samples", len(identity_records))
+    return identity_records
+
+
+def _mix_identity_data(
+    base_records: List[Dict[str, str]],
+    identity_records: List[Dict[str, str]],
+    mix_ratio: float,
+    seed: int,
+) -> List[Dict[str, str]]:
+    if not identity_records or mix_ratio <= 0:
+        return base_records
+
+    rng = random.Random(seed)
+    mixed_records: List[Dict[str, str]] = []
+    replacements = 0
+
+    # Map normalized questions to persona records when those questions exist in the base dataset.
+    normalized_mapping: Dict[str, Dict[str, str]] = {}
+    for record in identity_records:
+        key = record["question"].strip()
+        if key in normalized_mapping:
+            LOGGER.debug("Duplicate persona sample detected for question: %s", key)
+            continue
+        normalized_mapping[key] = record
+
+    for base_record in base_records:
+        key = base_record["question"].strip()
+        persona_record = normalized_mapping.get(key)
+        if persona_record:
+            merged = dict(base_record)
+            merged["answer"] = persona_record["answer"]
+            if persona_record.get("think"):
+                merged["think"] = persona_record["think"]
+            mixed_records.append(merged)
+            replacements += 1
+        else:
+            mixed_records.append(base_record)
+
+    # Append persona samples that do not correspond to existing dataset questions.
+    base_questions = {item["question"].strip() for item in base_records}
+    unmatched = [
+        record
+        for record in identity_records
+        if record["question"].strip() not in base_questions
+    ]
+    if unmatched:
+        mixed_records.extend(unmatched)
+
+    rng.shuffle(mixed_records)
+    LOGGER.info(
+        "Persona data merged into training set (replaced=%d, appended=%d).",
+        replacements,
+        len(unmatched),
+    )
+    return mixed_records
+
+
+def _convert_to_instruction_format(
+    prompt: str, records: Sequence[Dict[str, str]]
+) -> List[Dict[str, str]]:
+    formatted: List[Dict[str, str]] = []
+    for item in records:
+        question = item["question"].strip()
+        think = item.get("think", "").strip()
+        answer = item.get("answer", "").strip()
+        output = f"<think>{think}</think>\n{answer}"
+        formatted.append(
+            {
+                "instruction": prompt,
+                "input": question,
+                "output": output,
+            }
+        )
+    return formatted
+
+
+def _tokenize_dataset(
+    tokenizer: AutoTokenizer,
+    prompt: str,
+    dataset: Dataset,
+    max_length: int,
+) -> Dataset:
+    def _process_func(example: Dict[str, str]) -> Dict[str, List[int]]:
+        instruction = tokenizer(
+            f"<|im_start|>system\n{prompt}<|im_end|>\n"
+            f"<|im_start|>user\n{example['input']}<|im_end|>\n"
+            "<|im_start|>assistant\n",
+            add_special_tokens=False,
+        )
+        response = tokenizer(example["output"], add_special_tokens=False)
+        input_ids = (
+            instruction["input_ids"] + response["input_ids"] + [tokenizer.pad_token_id]
+        )
+        attention_mask = (
+            instruction["attention_mask"]
+            + response["attention_mask"]
+            + [1]
+        )
+        labels = (
+            [-100] * len(instruction["input_ids"])
+            + response["input_ids"]
+            + [tokenizer.pad_token_id]
+        )
+        input_ids = input_ids[:max_length]
+        attention_mask = attention_mask[:max_length]
+        labels = labels[:max_length]
+        return {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "labels": labels,
+        }
+
+    return dataset.map(_process_func, remove_columns=dataset.column_names)
+
+
+def _build_trainer(
+    config: IdentityFineTuneConfig,
+    model: AutoModelForCausalLM,
+    tokenizer: AutoTokenizer,
+    train_dataset: Dataset,
+    eval_dataset: Dataset,
+) -> Trainer:
+    training_args = TrainingArguments(
+        output_dir=config.output_dir,
+        per_device_train_batch_size=config.per_device_batch_size,
+        per_device_eval_batch_size=config.per_device_eval_batch_size,
+        gradient_accumulation_steps=config.gradient_accumulation_steps,
+        evaluation_strategy="steps",
+        eval_steps=config.eval_steps,
+        logging_steps=config.logging_steps,
+        num_train_epochs=config.train_epochs,
+        save_steps=config.save_steps,
+        learning_rate=config.learning_rate,
+        gradient_checkpointing=config.gradient_checkpointing,
+        report_to="swanlab",
+        run_name=config.run_name,
+        save_on_each_node=True,
+    )
+
+    data_collator = DataCollatorForSeq2Seq(tokenizer=tokenizer, padding=True)
+
+    return Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
+        data_collator=data_collator,
+    )
+
+
+def _log_predictions(
+    config: IdentityFineTuneConfig,
+    tokenizer: AutoTokenizer,
+    model: AutoModelForCausalLM,
+    formatted_records: Sequence[Dict[str, str]],
+) -> None:
+    preview = list(formatted_records)[: config.predictions_to_log]
+    if not preview:
+        return
+
+    logs: List[swanlab.Text] = []
+    for record in preview:
+        messages = [
+            {"role": "system", "content": record["instruction"]},
+            {"role": "user", "content": record["input"]},
+        ]
+        prompt_text = tokenizer.apply_chat_template(
+            messages,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        inputs = tokenizer([prompt_text], return_tensors="pt").to(model.device)
+        with torch.no_grad():
+            outputs = model.generate(
+                **inputs,
+                max_new_tokens=config.max_length,
+            )
+        generated = outputs[0][inputs["input_ids"].shape[-1] :]
+        decoded = tokenizer.decode(generated, skip_special_tokens=True)
+        preview_text = (
+            f"Question: {record['input']}\n\n"
+            f"Ground Truth: {record['output']}\n\n"
+            f"Model Output: {decoded}"
+        )
+        logs.append(swanlab.Text(preview_text))
+    if logs:
+        swanlab.log({"predictions": logs})
+
+
+def run_identity_finetune_pipeline(config: IdentityFineTuneConfig) -> None:
+    """Execute the full persona-aligned fine-tuning workflow."""
+    logging.basicConfig(level=logging.INFO)
+
+    _set_seed(config.seed)
+    _ensure_directory(config.work_dir)
+    _ensure_directory(config.output_dir)
+    _ensure_directory(config.cache_dir)
+
+    raw_dataset_path = os.path.join(config.work_dir, "raw_dataset.jsonl")
+    train_dataset_path = os.path.join(config.work_dir, "train.jsonl")
+    val_dataset_path = os.path.join(config.work_dir, "val.jsonl")
+    identity_dataset_path = os.path.join(config.work_dir, "identity.jsonl")
+    mixed_dataset_path = os.path.join(config.work_dir, "train_mixed.jsonl")
+    train_formatted_path = os.path.join(config.work_dir, "train_format.jsonl")
+    val_formatted_path = os.path.join(config.work_dir, "val_format.jsonl")
+
+    swanlab.config.update(
+        {
+            "model": config.base_model_repo,
+            "prompt": config.prompt,
+            "persona": config.persona.persona_name,
+            "data_max_length": config.max_length,
+        }
+    )
+
+    if os.path.exists(train_dataset_path) and os.path.exists(val_dataset_path):
+        LOGGER.info("Reusing existing dataset splits from %s", config.work_dir)
+        train_records = _jsonl_load(train_dataset_path)
+        val_records = _jsonl_load(val_dataset_path)
+        if os.path.exists(raw_dataset_path):
+            dataset_records = _jsonl_load(raw_dataset_path)
+        else:
+            dataset_records = train_records + val_records
+            _jsonl_dump(dataset_records, raw_dataset_path)
+    else:
+        dataset_records = _download_dataset(config)
+        _jsonl_dump(dataset_records, raw_dataset_path)
+        train_records, val_records = _split_dataset(
+            dataset_records, config.train_split_ratio, config.seed
+        )
+        _jsonl_dump(train_records, train_dataset_path)
+        _jsonl_dump(val_records, val_dataset_path)
+
+    local_model_dir = snapshot_download(
+        config.base_model_repo,
+        cache_dir=config.cache_dir,
+        revision=config.base_model_revision,
+    )
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        local_model_dir,
+        use_fast=False,
+        trust_remote_code=True,
+    )
+    if tokenizer.pad_token_id is None and tokenizer.eos_token_id is not None:
+        tokenizer.pad_token = tokenizer.eos_token
+    model = AutoModelForCausalLM.from_pretrained(
+        local_model_dir,
+        device_map="auto",
+        torch_dtype=torch.bfloat16,
+    )
+    if getattr(model.config, "pad_token_id", None) is None and tokenizer.pad_token_id is not None:
+        model.config.pad_token_id = tokenizer.pad_token_id
+    model.enable_input_require_grads()
+
+    model.eval()
+    identity_records = _generate_identity_samples(
+        config, tokenizer, model, train_records
+    )
+    model.train()
+    export_identity_records = [
+        {k: v for k, v in record.items() if k != "source_index"}
+        for record in identity_records
+    ]
+    _jsonl_dump(export_identity_records, identity_dataset_path)
+
+    mixed_train_records = _mix_identity_data(
+        train_records,
+        identity_records,
+        config.persona.mix_ratio,
+        config.seed,
+    )
+    mixed_train_records = [
+        {k: v for k, v in record.items() if k != "source_index"}
+        for record in mixed_train_records
+    ]
+    _jsonl_dump(mixed_train_records, mixed_dataset_path)
+
+    train_formatted = _convert_to_instruction_format(config.prompt, mixed_train_records)
+    val_formatted = _convert_to_instruction_format(config.prompt, val_records)
+    _jsonl_dump(train_formatted, train_formatted_path)
+    _jsonl_dump(val_formatted, val_formatted_path)
+
+    train_df = pd.read_json(train_formatted_path, lines=True)
+    val_df = pd.read_json(val_formatted_path, lines=True)
+
+    train_dataset = Dataset.from_pandas(train_df)
+    val_dataset = Dataset.from_pandas(val_df)
+
+    tokenized_train = _tokenize_dataset(
+        tokenizer, config.prompt, train_dataset, config.max_length
+    )
+    tokenized_val = _tokenize_dataset(
+        tokenizer, config.prompt, val_dataset, config.max_length
+    )
+
+    trainer = _build_trainer(
+        config, model, tokenizer, tokenized_train, tokenized_val
+    )
+
+    swanlab.init(
+        project=os.environ.get("SWANLAB_PROJECT", config.run_name),
+        run_name=config.run_name,
+    )
+    try:
+        trainer.train()
+        _log_predictions(config, tokenizer, model, train_formatted)
+    finally:
+        swanlab.finish()
+
+
+__all__ = [
+    "IdentityFineTuneConfig",
+    "PersonaSpecification",
+    "run_identity_finetune_pipeline",
+]

--- a/scripts/run_qwen_identity_finetune.py
+++ b/scripts/run_qwen_identity_finetune.py
@@ -1,0 +1,207 @@
+"""Command line helper to run the Qwen identity fine-tuning workflow."""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+
+def _ensure_repo_import_path() -> None:
+    """Add the repository root to ``sys.path`` when executed as a script."""
+
+    repo_root = Path(__file__).resolve().parents[1]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+
+_ensure_repo_import_path()
+
+
+def _load_pipeline_modules():
+    from examples.qwen_identity_finetune.pipeline import (  # noqa: E402
+        IdentityFineTuneConfig,
+        PersonaSpecification,
+        run_identity_finetune_pipeline,
+    )
+
+    return IdentityFineTuneConfig, PersonaSpecification, run_identity_finetune_pipeline
+
+_DEFAULT_PERSONA_STATEMENT = (
+    "你是一位善于共情、用语温和的医学专家，擅长通过先思考再回答的方式"
+    "为患者提供循序渐进的指导。请确保你的回复先展示思考过程，再给出最终答复。"
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run the Qwen persona identity fine-tuning workflow end-to-end.",
+    )
+    parser.add_argument(
+        "--work-dir",
+        default="./qwen_identity_workspace",
+        help="Directory used to store datasets, checkpoints, and logs.",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        default="./pretrained",
+        help="Cache directory for downloaded base models from ModelScope.",
+    )
+    parser.add_argument(
+        "--persona-name",
+        default="Dr. Grace",
+        help="Display name of the persona identity.",
+    )
+    parser.add_argument(
+        "--persona-statement",
+        default=_DEFAULT_PERSONA_STATEMENT,
+        help="Natural language description that defines the persona identity.",
+    )
+    parser.add_argument(
+        "--warmup-question",
+        action="append",
+        dest="warmup_questions",
+        help="Optional extra question for generating additional persona-aligned samples."
+        " Can be provided multiple times.",
+    )
+    parser.add_argument(
+        "--identity-mix-ratio",
+        type=float,
+        default=0.25,
+        help="Portion of persona-aligned samples to mix into the base training set.",
+    )
+    parser.add_argument(
+        "--train-split-ratio",
+        type=float,
+        default=0.9,
+        help="Proportion of the dataset used for training (remainder used for validation).",
+    )
+    parser.add_argument(
+        "--max-identity-samples",
+        type=int,
+        default=None,
+        help="Optional upper bound on the number of persona samples to generate.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed for dataset splitting and sampling.",
+    )
+    parser.add_argument(
+        "--base-model-repo",
+        default="Qwen/Qwen3-1.7B",
+        help="ModelScope repository name of the base Qwen model.",
+    )
+    parser.add_argument(
+        "--base-model-revision",
+        default="master",
+        help="Revision identifier for the base model (branch, tag, or commit).",
+    )
+    parser.add_argument(
+        "--learning-rate",
+        type=float,
+        default=1e-4,
+        help="Learning rate used during fine-tuning.",
+    )
+    parser.add_argument(
+        "--per-device-batch-size",
+        type=int,
+        default=1,
+        help="Per-device batch size for both training and evaluation.",
+    )
+    parser.add_argument(
+        "--gradient-accumulation-steps",
+        type=int,
+        default=4,
+        help="Number of gradient accumulation steps.",
+    )
+    parser.add_argument(
+        "--train-epochs",
+        type=int,
+        default=1,
+        help="Number of fine-tuning epochs to run.",
+    )
+    parser.add_argument(
+        "--eval-steps",
+        type=int,
+        default=100,
+        help="How often to run evaluation (in steps).",
+    )
+    parser.add_argument(
+        "--logging-steps",
+        type=int,
+        default=10,
+        help="Frequency of logging training metrics (in steps).",
+    )
+    parser.add_argument(
+        "--save-steps",
+        type=int,
+        default=400,
+        help="Checkpoint save interval (in steps).",
+    )
+    parser.add_argument(
+        "--run-name",
+        default="qwen3-identity",
+        help="Run name used in SwanLab dashboards.",
+    )
+    parser.add_argument(
+        "--predictions-to-log",
+        type=int,
+        default=3,
+        help="Number of generated predictions to record in SwanLab at the end of training.",
+    )
+    parser.add_argument(
+        "--max-length",
+        type=int,
+        default=2048,
+        help="Maximum sequence length during tokenization.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+
+    IdentityFineTuneConfig, PersonaSpecification, run_identity_finetune_pipeline = (
+        _load_pipeline_modules()
+    )
+
+    warmup_questions = args.warmup_questions
+
+    persona = PersonaSpecification(
+        persona_name=args.persona_name,
+        identity_statement=args.persona_statement,
+        mix_ratio=args.identity_mix_ratio,
+        max_identity_samples=args.max_identity_samples,
+        warmup_questions=warmup_questions,
+    )
+
+    config = IdentityFineTuneConfig(
+        work_dir=args.work_dir,
+        persona=persona,
+        cache_dir=args.cache_dir,
+        seed=args.seed,
+        base_model_repo=args.base_model_repo,
+        base_model_revision=args.base_model_revision,
+        learning_rate=args.learning_rate,
+        per_device_batch_size=args.per_device_batch_size,
+        per_device_eval_batch_size=args.per_device_batch_size,
+        gradient_accumulation_steps=args.gradient_accumulation_steps,
+        train_epochs=args.train_epochs,
+        eval_steps=args.eval_steps,
+        logging_steps=args.logging_steps,
+        save_steps=args.save_steps,
+        run_name=args.run_name,
+        predictions_to_log=args.predictions_to_log,
+        max_length=args.max_length,
+        train_split_ratio=args.train_split_ratio,
+    )
+
+    os.environ.setdefault("SWANLAB_PROJECT", args.run_name)
+
+    run_identity_finetune_pipeline(config)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- update the identity fine-tuning pipeline to reuse cached dataset splits, sample persona-aligned answers from the training set, and cleanly merge persona data before SFT
- improve the run script with production defaults, optional warmup prompts, and a configurable train/validation split ratio
- refresh the tutorial to describe the dataset-driven identity generation workflow and new CLI options
- fix the identity pipeline to import the Hugging Face AutoTokenizer and align the tutorial snippet with the production code
- harden the automation by validating configuration inputs, defaulting pad tokens for Qwen, and making the runner CLI resolve repository imports lazily so `--help` works without optional dependencies

## Testing
- python -m compileall examples/qwen_identity_finetune scripts/run_qwen_identity_finetune.py

------
https://chatgpt.com/codex/tasks/task_e_68f1dde3e7f88330951d11c5b262c0cf