### PR TITLE
Enable automatic benchmark dataset downloads

### DIFF
--- a/src/evaluation/__init__.py
+++ b/src/evaluation/__init__.py
@@ -1,0 +1,15 @@
+"""Evaluation utilities for MiniGPT."""
+
+from .benchmark_suite import (
+    INDUSTRY_BENCHMARK_TASKS,
+    BenchmarkEvaluator,
+    BenchmarkSettings,
+    BenchmarkTask,
+)
+
+__all__ = [
+    "BenchmarkEvaluator",
+    "BenchmarkSettings",
+    "BenchmarkTask",
+    "INDUSTRY_BENCHMARK_TASKS",
+]

--- a/src/evaluation/benchmark_suite.py
+++ b/src/evaluation/benchmark_suite.py
@@ -1,0 +1,840 @@
+from __future__ import annotations
+
+"""Benchmark evaluation helpers for running industry-standard datasets during training.
+
+This module now covers both classic language-modeling corpora (WikiText, LAMBADA,
+Penn Treebank, C4) and the most widely cited instruction-following leaderboards such
+as HellaSwag, ARC (Easy/Challenge), Winogrande, PIQA, and BoolQ so the training
+pipeline can report accuracy-based metrics alongside perplexity in one place.
+"""
+
+import math
+import os
+import warnings
+from dataclasses import dataclass, field, replace
+from typing import Any, Callable, Iterable, Sequence
+
+import torch
+import torch.nn.functional as F
+try:
+    from datasets import load_dataset
+except Exception as exc:  # pragma: no cover - optional dependency
+    load_dataset = None
+    _DATASETS_IMPORT_ERROR = exc
+else:  # pragma: no cover - trivial branch
+    _DATASETS_IMPORT_ERROR = None
+from torch.utils.data import DataLoader
+
+
+@dataclass
+class MultipleChoiceInstance:
+    """Raw text sample for a multiple choice benchmark."""
+
+    prompt: str
+    options: Sequence[str]
+    answer_index: int
+
+
+@dataclass
+class EncodedMultipleChoice:
+    """Tokenized representation of a multiple choice instance."""
+
+    prompt_ids: list[int]
+    option_ids: list[list[int]]
+    answer_index: int
+
+
+@dataclass
+class BenchmarkTask:
+    """Definition for a single benchmark evaluation task."""
+
+    name: str
+    dataset_name: str
+    dataset_config: str | None = None
+    split: str = "test"
+    text_column: str = "text"
+    max_samples: int = 256
+    batch_size: int = 4
+    max_length: int | None = None
+    task_type: str = "language_modeling"
+    processor: Callable[[dict[str, Any]], MultipleChoiceInstance | None] | None = field(
+        default=None, repr=False
+    )
+
+
+def _hellaswag_processor(sample: dict[str, Any]) -> MultipleChoiceInstance | None:
+    ctx_a = (sample.get("ctx_a") or "").strip()
+    ctx_b = (sample.get("ctx_b") or "").strip()
+    prompt = f"{ctx_a} {ctx_b}".strip()
+    endings = sample.get("endings")
+    label = sample.get("label")
+    if isinstance(endings, str) or not isinstance(endings, Sequence) or len(endings) == 0:
+        return None
+    try:
+        answer_index = int(label)
+    except (TypeError, ValueError):
+        return None
+    options = [f" {ending.strip()}" for ending in endings]
+    return MultipleChoiceInstance(prompt=prompt, options=options, answer_index=answer_index)
+
+
+def _arc_processor(sample: dict[str, Any]) -> MultipleChoiceInstance | None:
+    question = (sample.get("question") or "").strip()
+    choices = sample.get("choices") or {}
+    options = choices.get("text") or []
+    if isinstance(options, str) or not isinstance(options, Sequence) or len(options) == 0:
+        return None
+    answer_key = (sample.get("answerKey") or "").strip()
+    labels = choices.get("label") or []
+    indexed_options: list[str] = []
+    answer_index = None
+    for idx, option_text in enumerate(options):
+        label = labels[idx] if idx < len(labels) else None
+        display_label = (label or chr(ord("A") + idx)).strip()
+        indexed_options.append(f"{display_label}. {option_text}")
+        if answer_key and answer_key.upper() == display_label.upper():
+            answer_index = idx
+    if answer_index is None:
+        return None
+    prompt_lines = [f"Question: {question}", "Choices:"]
+    for option in indexed_options:
+        prompt_lines.append(option)
+    prompt_lines.append("Answer:")
+    prompt = "\n".join(prompt_lines)
+    completions = [f" {chr(ord('A') + idx)}" for idx in range(len(indexed_options))]
+    return MultipleChoiceInstance(prompt=prompt, options=completions, answer_index=answer_index)
+
+
+def _winogrande_processor(sample: dict[str, Any]) -> MultipleChoiceInstance | None:
+    sentence = (sample.get("sentence") or "").strip()
+    option1 = sample.get("option1")
+    option2 = sample.get("option2")
+    answer = sample.get("answer")
+    if option1 is None or option2 is None:
+        return None
+    prompt = f"Fill in the blank: {sentence}\nAnswer:"
+    options = [f" {str(option1).strip()}", f" {str(option2).strip()}"]
+    try:
+        answer_index = int(str(answer).strip()) - 1
+    except (TypeError, ValueError):
+        if str(answer).strip().upper() == "1":
+            answer_index = 0
+        elif str(answer).strip().upper() == "2":
+            answer_index = 1
+        else:
+            return None
+    if answer_index not in (0, 1):
+        return None
+    return MultipleChoiceInstance(prompt=prompt, options=options, answer_index=answer_index)
+
+
+def _piqa_processor(sample: dict[str, Any]) -> MultipleChoiceInstance | None:
+    goal = (sample.get("goal") or "").strip()
+    sol1 = (sample.get("sol1") or "").strip()
+    sol2 = (sample.get("sol2") or "").strip()
+    label = sample.get("label")
+    try:
+        answer_index = int(label)
+    except (TypeError, ValueError):
+        return None
+    prompt = f"Goal: {goal}\nBest solution:"
+    options = [f" {sol1}", f" {sol2}"]
+    return MultipleChoiceInstance(prompt=prompt, options=options, answer_index=answer_index)
+
+
+def _boolq_processor(sample: dict[str, Any]) -> MultipleChoiceInstance | None:
+    question = (sample.get("question") or "").strip()
+    passage = (sample.get("passage") or "").strip()
+    answer = sample.get("answer")
+    if answer is None:
+        return None
+    prompt = (
+        f"Passage: {passage}\nQuestion: {question}\nAnswer (yes or no):"
+    )
+    answer_index = 1 if bool(answer) else 0
+    options = [" yes", " no"]
+    return MultipleChoiceInstance(prompt=prompt, options=options, answer_index=answer_index)
+
+
+INDUSTRY_BENCHMARK_TASKS: dict[str, BenchmarkTask] = {
+    "wikitext2": BenchmarkTask(
+        name="wikitext2",
+        dataset_name="wikitext",
+        dataset_config="wikitext-2-raw-v1",
+        split="test",
+        text_column="text",
+        max_samples=256,
+        batch_size=4,
+        max_length=1024,
+    ),
+    "wikitext103": BenchmarkTask(
+        name="wikitext103",
+        dataset_name="wikitext",
+        dataset_config="wikitext-103-raw-v1",
+        split="test",
+        text_column="text",
+        max_samples=256,
+        batch_size=4,
+        max_length=1024,
+    ),
+    "lambada_openai": BenchmarkTask(
+        name="lambada_openai",
+        dataset_name="lambada",
+        dataset_config="openai",
+        split="test",
+        text_column="text",
+        max_samples=500,
+        batch_size=4,
+        max_length=1024,
+    ),
+    "ptb": BenchmarkTask(
+        name="ptb",
+        dataset_name="ptb_text_only",
+        dataset_config="penn_treebank",
+        split="test",
+        text_column="sentence",
+        max_samples=512,
+        batch_size=8,
+        max_length=512,
+    ),
+    "c4_en": BenchmarkTask(
+        name="c4_en",
+        dataset_name="c4",
+        dataset_config="en",
+        split="validation",
+        text_column="text",
+        max_samples=128,
+        batch_size=2,
+        max_length=512,
+    ),
+    "hellaswag": BenchmarkTask(
+        name="hellaswag",
+        dataset_name="hellaswag",
+        split="validation",
+        max_samples=500,
+        batch_size=1,
+        max_length=512,
+        task_type="multiple_choice",
+        processor=_hellaswag_processor,
+    ),
+    "arc_easy": BenchmarkTask(
+        name="arc_easy",
+        dataset_name="ai2_arc",
+        dataset_config="ARC-Easy",
+        split="validation",
+        max_samples=500,
+        batch_size=1,
+        max_length=512,
+        task_type="multiple_choice",
+        processor=_arc_processor,
+    ),
+    "arc_challenge": BenchmarkTask(
+        name="arc_challenge",
+        dataset_name="ai2_arc",
+        dataset_config="ARC-Challenge",
+        split="validation",
+        max_samples=500,
+        batch_size=1,
+        max_length=512,
+        task_type="multiple_choice",
+        processor=_arc_processor,
+    ),
+    "winogrande": BenchmarkTask(
+        name="winogrande",
+        dataset_name="winogrande",
+        dataset_config="winogrande_xl",
+        split="validation",
+        max_samples=500,
+        batch_size=1,
+        max_length=512,
+        task_type="multiple_choice",
+        processor=_winogrande_processor,
+    ),
+    "piqa": BenchmarkTask(
+        name="piqa",
+        dataset_name="piqa",
+        split="validation",
+        max_samples=500,
+        batch_size=1,
+        max_length=512,
+        task_type="multiple_choice",
+        processor=_piqa_processor,
+    ),
+    "boolq": BenchmarkTask(
+        name="boolq",
+        dataset_name="super_glue",
+        dataset_config="boolq",
+        split="validation",
+        max_samples=256,
+        batch_size=1,
+        max_length=512,
+        task_type="multiple_choice",
+        processor=_boolq_processor,
+    ),
+}
+
+
+@dataclass
+class BenchmarkSettings:
+    """Configuration for running benchmark evaluations."""
+
+    tasks: Sequence[BenchmarkTask]
+    frequency: int = 500
+    cache_dir: str | None = None
+    auto_download: bool = True
+
+    @classmethod
+    def from_task_names(
+        cls,
+        task_names: Iterable[str],
+        *,
+        frequency: int,
+        max_samples: int | None,
+        batch_size: int | None,
+        max_length: int | None,
+        overrides: dict[str, str | None] | None = None,
+        cache_dir: str | None = None,
+        auto_download: bool = True,
+    ) -> "BenchmarkSettings":
+        tasks: list[BenchmarkTask] = []
+        overrides = overrides or {}
+        for raw_name in task_names:
+            name = raw_name.strip()
+            if not name:
+                continue
+            task = _resolve_task(
+                name,
+                max_samples=max_samples,
+                batch_size=batch_size,
+                max_length=max_length,
+                overrides=overrides,
+            )
+            if task is not None:
+                tasks.append(task)
+
+        if not tasks:
+            raise ValueError(
+                "No benchmark tasks resolved. Please configure MINIGPT_BENCHMARK_TASKS or overrides correctly."
+            )
+
+        return cls(
+            tasks=tasks,
+            frequency=max(1, frequency),
+            cache_dir=cache_dir,
+            auto_download=auto_download,
+        )
+
+
+def _resolve_task(
+    task_name: str,
+    *,
+    max_samples: int | None,
+    batch_size: int | None,
+    max_length: int | None,
+    overrides: dict[str, str | None],
+) -> BenchmarkTask | None:
+    key = task_name.lower()
+    base = INDUSTRY_BENCHMARK_TASKS.get(key)
+
+    if base is None and overrides.get("dataset_name"):
+        # Custom dataset defined through overrides.
+        base = BenchmarkTask(
+            name=task_name,
+            dataset_name=overrides["dataset_name"],
+            dataset_config=overrides.get("dataset_config"),
+            split=overrides.get("split") or "test",
+            text_column=overrides.get("text_column") or "text",
+            max_samples=max_samples or 256,
+            batch_size=batch_size or 4,
+            max_length=max_length,
+        )
+    elif base is None:
+        warnings.warn(
+            f"Unknown benchmark task '{task_name}'. Skipping this entry.",
+            RuntimeWarning,
+        )
+        return None
+
+    task = replace(base, name=task_name)
+
+    if overrides.get("dataset_name"):
+        task = replace(task, dataset_name=overrides["dataset_name"])
+    if overrides.get("dataset_config"):
+        task = replace(task, dataset_config=overrides.get("dataset_config"))
+    if overrides.get("split"):
+        task = replace(task, split=overrides.get("split"))
+    if overrides.get("text_column"):
+        task = replace(task, text_column=overrides.get("text_column"))
+
+    if max_samples:
+        task = replace(task, max_samples=max_samples)
+    if batch_size:
+        task = replace(task, batch_size=batch_size)
+    if max_length:
+        task = replace(task, max_length=max_length)
+
+    return task
+
+
+class BenchmarkEvaluator:
+    """Execute perplexity-style benchmarks on public evaluation datasets."""
+
+    def __init__(
+        self,
+        *,
+        device: torch.device | str,
+        tokenizer,
+        settings: BenchmarkSettings,
+    ) -> None:
+        self.device = torch.device(device)
+        self.tokenizer = tokenizer
+        self.settings = settings
+        self.pad_id = getattr(tokenizer, "pad_id", 0)
+        self._cached_sequences: dict[str, list[list[int]]] = {}
+        self._cached_multiple_choice: dict[str, list[EncodedMultipleChoice]] = {}
+        self._disabled_reasons: dict[str, str] = {}
+        self._last_step: int | None = None
+
+        if self.settings.cache_dir:
+            os.makedirs(self.settings.cache_dir, exist_ok=True)
+        if self.settings.auto_download:
+            self._auto_download_datasets()
+
+    # ------------------------------------------------------------------
+    def should_run(self, step: int) -> bool:
+        """Return True when the benchmark should execute for this step."""
+
+        if not self.enabled:
+            return False
+        if step <= 0:
+            return False
+        return step % max(1, self.settings.frequency) == 0
+
+    # ------------------------------------------------------------------
+    @property
+    def enabled(self) -> bool:
+        return any(task.name not in self._disabled_reasons for task in self.settings.tasks)
+
+    # ------------------------------------------------------------------
+    def maybe_run(
+        self,
+        model: torch.nn.Module,
+        step: int,
+        monitor,
+        *,
+        force: bool = False,
+    ) -> dict[str, dict[str, float]] | None:
+        """Run the benchmark when required."""
+
+        if not self.enabled:
+            return None
+        if not force and not self.should_run(step):
+            return None
+        if self._last_step == step:
+            return None
+
+        metrics: dict[str, dict[str, float]] = {}
+        for task in self.settings.tasks:
+            if task.name in self._disabled_reasons:
+                continue
+            task_metrics = self._run_task(task, model)
+            if task_metrics is None:
+                continue
+            metrics[task.name] = task_metrics
+            if hasattr(monitor, "log_benchmark"):
+                monitor.log_benchmark(step, task_metrics, task=task.name)
+
+        if metrics:
+            self._last_step = step
+            return metrics
+        return None
+
+    # ------------------------------------------------------------------
+    def _run_task(
+        self,
+        task: BenchmarkTask,
+        model: torch.nn.Module,
+    ) -> dict[str, float] | None:
+        if task.task_type == "multiple_choice":
+            return self._run_multiple_choice(task, model)
+        return self._run_language_modeling(task, model)
+
+    # ------------------------------------------------------------------
+    def _run_language_modeling(
+        self,
+        task: BenchmarkTask,
+        model: torch.nn.Module,
+    ) -> dict[str, float] | None:
+        sequences = self._prepare_language_modeling_sequences(task)
+        if not sequences:
+            return None
+
+        dataloader = DataLoader(
+            sequences,
+            batch_size=max(1, task.batch_size),
+            collate_fn=self._collate_batch,
+            shuffle=False,
+        )
+
+        was_training = model.training
+        model.eval()
+        total_nll = 0.0
+        total_tokens = 0
+
+        with torch.no_grad():
+            for batch in dataloader:
+                batch = batch.to(self.device)
+                input_ids = batch[:, :-1]
+                targets = batch[:, 1:]
+                logits = model(input_ids)
+                loss = F.cross_entropy(
+                    logits.reshape(-1, logits.size(-1)),
+                    targets.reshape(-1),
+                    ignore_index=self.pad_id,
+                    reduction="sum",
+                )
+                valid_tokens = torch.count_nonzero(targets != self.pad_id).item()
+                total_nll += float(loss.item())
+                total_tokens += int(valid_tokens)
+
+        if was_training:
+            model.train()
+
+        if total_tokens == 0:
+            reason = f"Benchmark '{task.name}' skipped due to empty token count"
+            warnings.warn(reason, RuntimeWarning)
+            self._disabled_reasons[task.name] = reason
+            return None
+
+        avg_nll = total_nll / total_tokens
+        perplexity = math.exp(min(20.0, avg_nll))
+        return {
+            "loss": avg_nll,
+            "perplexity": perplexity,
+            "tokens": float(total_tokens),
+        }
+
+    # ------------------------------------------------------------------
+    def _prepare_language_modeling_sequences(
+        self, task: BenchmarkTask
+    ) -> list[list[int]] | None:
+        if task.name in self._cached_sequences:
+            return self._cached_sequences[task.name]
+        if task.name in self._disabled_reasons:
+            return None
+
+        dataset_split = self._load_dataset_split(task)
+        if dataset_split is None:
+            return None
+
+        sequences: list[list[int]] = []
+        max_samples = max(1, task.max_samples)
+        max_length = self._resolve_max_length(task)
+        text_column = task.text_column
+        for item in dataset_split:
+            text = item.get(text_column)
+            if not text:
+                continue
+            tokens = self.tokenizer.encode(text, add_special_tokens=True)
+            if len(tokens) < 2:
+                continue
+            start = 0
+            while start + 1 < len(tokens):
+                window = tokens[start : start + max_length + 1]
+                if len(window) < 2:
+                    break
+                sequences.append(window)
+                if len(sequences) >= max_samples:
+                    break
+                start += max_length
+            if len(sequences) >= max_samples:
+                break
+
+        if not sequences:
+            self._disabled_reasons[task.name] = "No evaluable sequences prepared"
+            print(
+                f"⚠️  Benchmark evaluator disabled for {task.name}: {self._disabled_reasons[task.name]}"
+            )
+            return None
+
+        self._cached_sequences[task.name] = sequences
+        return sequences
+
+    # ------------------------------------------------------------------
+    def _prepare_multiple_choice(
+        self, task: BenchmarkTask
+    ) -> list[EncodedMultipleChoice] | None:
+        if task.name in self._cached_multiple_choice:
+            return self._cached_multiple_choice[task.name]
+        if task.name in self._disabled_reasons:
+            return None
+        if task.processor is None:
+            self._disabled_reasons[task.name] = "No processor defined for multiple choice task"
+            return None
+
+        dataset_split = self._load_dataset_split(task)
+        if dataset_split is None:
+            return None
+
+        max_samples = max(1, task.max_samples)
+        max_length = self._resolve_max_length(task)
+        prepared: list[EncodedMultipleChoice] = []
+        for sample in dataset_split:
+            instance = task.processor(sample)
+            if instance is None:
+                continue
+            encoded = self._encode_multiple_choice(instance, max_length)
+            if encoded is None:
+                continue
+            prepared.append(encoded)
+            if len(prepared) >= max_samples:
+                break
+
+        if not prepared:
+            self._disabled_reasons[task.name] = "No evaluable multiple choice samples"
+            print(
+                f"⚠️  Benchmark evaluator disabled for {task.name}: {self._disabled_reasons[task.name]}"
+            )
+            return None
+
+        self._cached_multiple_choice[task.name] = prepared
+        return prepared
+
+    # ------------------------------------------------------------------
+    def _run_multiple_choice(
+        self,
+        task: BenchmarkTask,
+        model: torch.nn.Module,
+    ) -> dict[str, float] | None:
+        samples = self._prepare_multiple_choice(task)
+        if not samples:
+            return None
+
+        was_training = model.training
+        model.eval()
+
+        correct = 0
+        total = 0
+        total_log_prob = 0.0
+        total_tokens = 0
+
+        with torch.no_grad():
+            for encoded in samples:
+                scores: list[float] = []
+                option_lengths: list[int] = []
+                for option_ids in encoded.option_ids:
+                    full_ids = torch.tensor(
+                        encoded.prompt_ids + option_ids,
+                        dtype=torch.long,
+                        device=self.device,
+                    )
+                    if full_ids.numel() < 2:
+                        scores.append(float("-inf"))
+                        option_lengths.append(0)
+                        continue
+                    input_ids = full_ids[:-1].unsqueeze(0)
+                    targets = full_ids[1:].unsqueeze(0)
+                    logits = model(input_ids)
+                    log_probs = F.log_softmax(logits, dim=-1)
+                    start_index = max(len(encoded.prompt_ids) - 1, 0)
+                    option_targets = targets[:, start_index:]
+                    option_log_probs = log_probs[:, start_index:]
+                    gathered = option_log_probs.gather(
+                        -1, option_targets.unsqueeze(-1)
+                    ).squeeze(-1)
+                    score = float(gathered.sum().item())
+                    scores.append(score)
+                    option_lengths.append(int(option_targets.numel()))
+
+                if not scores:
+                    continue
+
+                predicted = int(torch.tensor(scores).argmax().item())
+                if predicted == encoded.answer_index:
+                    correct += 1
+                correct_option_tokens = option_lengths[encoded.answer_index]
+                total_tokens += correct_option_tokens
+                total_log_prob += scores[encoded.answer_index]
+                total += 1
+
+        if was_training:
+            model.train()
+
+        if total == 0:
+            reason = f"Benchmark '{task.name}' skipped due to missing valid samples"
+            warnings.warn(reason, RuntimeWarning)
+            self._disabled_reasons[task.name] = reason
+            return None
+
+        accuracy = correct / total
+        avg_log_prob = total_log_prob / max(total, 1)
+        metrics = {
+            "accuracy": accuracy,
+            "samples": float(total),
+            "avg_log_prob": avg_log_prob,
+        }
+        if total_tokens > 0:
+            metrics["avg_correct_token_logprob"] = total_log_prob / max(total_tokens, 1)
+        return metrics
+
+    # ------------------------------------------------------------------
+    def _auto_download_datasets(self) -> None:
+        if load_dataset is None:
+            return
+
+        load_kwargs: dict[str, Any] = {"download_mode": "reuse_dataset_if_exists"}
+        if self.settings.cache_dir:
+            load_kwargs["cache_dir"] = self.settings.cache_dir
+
+        for task in self.settings.tasks:
+            if task.name in self._disabled_reasons:
+                continue
+            try:
+                if task.dataset_config:
+                    dataset = load_dataset(
+                        task.dataset_name,
+                        task.dataset_config,
+                        split=task.split,
+                        **load_kwargs,
+                    )
+                else:
+                    dataset = load_dataset(
+                        task.dataset_name,
+                        split=task.split,
+                        **load_kwargs,
+                    )
+            except Exception as exc:  # pragma: no cover - depends on network access
+                print(
+                    f"⚠️  Failed to pre-download benchmark dataset '{task.name}': {exc}"
+                )
+                continue
+
+            # Materialize at least one record to trigger download when streaming.
+            try:
+                iterator = iter(dataset)
+                next(iterator)
+            except StopIteration:
+                pass
+            except TypeError:
+                # Some dataset types are not iterable (e.g., map-style). Ignore.
+                pass
+            finally:
+                del dataset
+
+    # ------------------------------------------------------------------
+    def _load_dataset_split(self, task: BenchmarkTask):
+        if load_dataset is None:
+            reason = "'datasets' library is not available"
+            if _DATASETS_IMPORT_ERROR is not None:
+                reason = f"datasets import error: {_DATASETS_IMPORT_ERROR}"
+            self._disabled_reasons[task.name] = reason
+            print(f"⚠️  Benchmark evaluator disabled for {task.name}: {reason}")
+            return None
+
+        load_kwargs: dict[str, Any] = {"download_mode": "reuse_dataset_if_exists"}
+        if self.settings.cache_dir:
+            load_kwargs["cache_dir"] = self.settings.cache_dir
+
+        try:
+            if task.dataset_config:
+                dataset = load_dataset(
+                    task.dataset_name,
+                    task.dataset_config,
+                    split=task.split,
+                    **load_kwargs,
+                )
+            else:
+                dataset = load_dataset(
+                    task.dataset_name,
+                    split=task.split,
+                    **load_kwargs,
+                )
+        except Exception as exc:  # pragma: no cover - network/runtime dependent
+            self._disabled_reasons[task.name] = f"Failed to load dataset: {exc}"
+            print(
+                f"⚠️  Benchmark evaluator disabled for {task.name}: {self._disabled_reasons[task.name]}"
+            )
+            return None
+
+        return dataset
+
+    # ------------------------------------------------------------------
+    def _resolve_max_length(self, task: BenchmarkTask) -> int:
+        if task.max_length and task.max_length > 0:
+            return int(task.max_length)
+        for attr in ("max_length", "model_max_length"):
+            value = getattr(self.tokenizer, attr, None)
+            if isinstance(value, int) and value > 0:
+                return value
+        return 512
+
+    # ------------------------------------------------------------------
+    def _encode_multiple_choice(
+        self, instance: MultipleChoiceInstance, max_length: int
+    ) -> EncodedMultipleChoice | None:
+        prompt_ids = self.tokenizer.encode(instance.prompt, add_special_tokens=False)
+        if not prompt_ids:
+            bos_id = getattr(self.tokenizer, "bos_id", None)
+            if bos_id is None:
+                bos_id = getattr(self.tokenizer, "bos_token_id", None)
+            if bos_id is None:
+                return None
+            prompt_ids = [int(bos_id)]
+
+        # Ensure prompt leaves room for at least one completion token.
+        max_prompt_len = max(max_length - 1, 1)
+        prompt_ids = prompt_ids[-max_prompt_len:]
+        allowed_completion = max_length - len(prompt_ids)
+        allowed_completion = max(allowed_completion, 1)
+
+        option_ids: list[list[int]] = []
+        for option in instance.options:
+            completion_ids = self.tokenizer.encode(option, add_special_tokens=False)
+            if not completion_ids:
+                return None
+            completion_ids = completion_ids[:allowed_completion]
+            if not completion_ids:
+                return None
+            option_ids.append([int(token) for token in completion_ids])
+
+        if instance.answer_index < 0 or instance.answer_index >= len(option_ids):
+            return None
+
+        return EncodedMultipleChoice(
+            prompt_ids=[int(token) for token in prompt_ids],
+            option_ids=option_ids,
+            answer_index=int(instance.answer_index),
+        )
+
+    # ------------------------------------------------------------------
+    def _collate_batch(self, batch: Sequence[Sequence[int]]) -> torch.Tensor:
+        max_len = max(len(seq) for seq in batch)
+        padded = torch.full((len(batch), max_len), self.pad_id, dtype=torch.long)
+        for idx, seq in enumerate(batch):
+            padded[idx, : len(seq)] = torch.tensor(seq, dtype=torch.long)
+        return padded
+
+    # ------------------------------------------------------------------
+    def status(self) -> dict[str, Any]:
+        """Return diagnostic information about the evaluator state."""
+
+        task_status = []
+        for task in self.settings.tasks:
+            if task.task_type == "multiple_choice":
+                cached = len(self._cached_multiple_choice.get(task.name, []))
+            else:
+                cached = len(self._cached_sequences.get(task.name, []))
+            task_status.append(
+                {
+                    "name": task.name,
+                    "enabled": task.name not in self._disabled_reasons,
+                    "disabled_reason": self._disabled_reasons.get(task.name),
+                    "cached_samples": cached,
+                }
+            )
+
+        return {
+            "enabled": self.enabled,
+            "tasks": task_status,
+            "frequency": self.settings.frequency,
+        }

--- a/src/training/pipeline/training_loop.py
+++ b/src/training/pipeline/training_loop.py
@@ -55,6 +55,7 @@ class TrainingLoopRunner:
         start_time: float,
         memory_hooks=None,
         regression_suite=None,
+        benchmark_evaluator=None,
     ) -> str:
         model.train()
         step = start_step
@@ -181,6 +182,9 @@ class TrainingLoopRunner:
                     if step >= self.config.max_steps:
                         break
 
+                    if benchmark_evaluator is not None:
+                        benchmark_evaluator.maybe_run(model, step, monitor)
+
             if step >= self.config.max_steps or control.interrupted:
                 break
 
@@ -196,6 +200,9 @@ class TrainingLoopRunner:
             print("💡 可使用 --auto-resume 从此处恢复训练")
 
         final_path = self.checkpoints.save_final(model, tokenizer, step)
+
+        if benchmark_evaluator is not None:
+            benchmark_evaluator.maybe_run(model, step, monitor, force=True)
 
         if control.interrupted:
             print("\n⚠️  训练被用户中断")


### PR DESCRIPTION
## Summary
- add configuration for benchmark cache location and optional auto-download toggle
- teach the benchmark evaluator to pre-download datasets into the configured cache directory and reuse it when loading splits
- wire the new cache and auto-download options into the training pipeline settings

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68f4616f10bc8330acd4cb2579f17fda