### PR TITLE
Add convenience script for one-click benchmark evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ uv run python scripts/run_smoke_pipeline.py
    print(tokenizer.decode(output_ids[0].tolist()))
    ```
 
+5. **一键行业评测**
+   ```bash
+   uv run python scripts/run_benchmark_eval.py --checkpoint path/to/checkpoint_step_*.pt
+   ```
+   > 默认自动在与 checkpoint 同目录的 `tokenizer.pkl` 上下文中加载模型与分词器，并跑通 WikiText-2、LAMBADA、HellaSwag、ARC、Winogrande、PIQA、BoolQ 等评测任务，结果会写入同目录下带时间戳的 `benchmark_results_*.json`。如需自定义任务或缓存目录，可通过 `--tasks`、`--cache-dir`、`--disable-auto-download` 等参数覆盖默认值。【F:scripts/run_benchmark_eval.py†L24-L134】【F:scripts/run_benchmark_eval.py†L155-L210】
+
 ## 📚 深入阅读
 - [docs/README.md](docs/README.md)：文档索引与阅读指引
 - [docs/getting_started.md](docs/getting_started.md)：环境配置与实践示例

--- a/scripts/run_benchmark_eval.py
+++ b/scripts/run_benchmark_eval.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Convenience wrapper for launching the benchmark evaluator on a saved checkpoint."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import torch
+
+# Ensure the repository root is on the module search path when executed directly.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.evaluation import BenchmarkEvaluator, BenchmarkSettings  # noqa: E402
+from src.model.config import MiniGPTConfig  # noqa: E402
+from src.model.transformer import MiniGPT  # noqa: E402
+from src.tokenizer.bpe_tokenizer import BPETokenizer  # noqa: E402
+
+DEFAULT_TASKS = [
+    "wikitext2",
+    "lambada_openai",
+    "hellaswag",
+    "arc_challenge",
+    "winogrande",
+    "piqa",
+    "boolq",
+]
+DEFAULT_CACHE_DIR = REPO_ROOT / "data" / "eval" / "benchmarks"
+
+
+class ConsoleBenchmarkLogger:
+    """Minimal logger compatible with :class:`BenchmarkEvaluator`."""
+
+    def log_benchmark(self, step: int, metrics: dict[str, float], *, task: str) -> None:
+        header = f"📊 Benchmark[{task}] (step={step})"
+        print(header)
+        for key, value in metrics.items():
+            print(f"  - {key}: {value}")
+
+
+def _resolve_device(name: str) -> torch.device:
+    if name == "auto":
+        if torch.cuda.is_available():
+            return torch.device("cuda")
+        if torch.backends.mps.is_available():  # type: ignore[attr-defined]
+            return torch.device("mps")
+        return torch.device("cpu")
+    return torch.device(name)
+
+
+def _load_model(checkpoint_path: Path, *, device: torch.device, vocab_size: int) -> MiniGPT:
+    checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+
+    config_dict: dict[str, Any] | None = None
+    if isinstance(checkpoint.get("model_config"), dict):
+        config_dict = checkpoint["model_config"]
+    elif isinstance(checkpoint.get("config"), dict):
+        config_dict = checkpoint["config"].get("model_config")  # type: ignore[union-attr]
+    else:
+        config_obj = checkpoint.get("config")
+        model_config_obj = getattr(config_obj, "model_config", None)
+        if model_config_obj is not None:
+            if isinstance(model_config_obj, dict):
+                config_dict = model_config_obj
+            elif hasattr(model_config_obj, "to_dict"):
+                config_dict = model_config_obj.to_dict()
+
+    if config_dict is None:
+        raise RuntimeError(
+            "无法从 checkpoint 解析模型配置。请确认 checkpoint 由训练流水线保存，且包含 'model_config' 字段。"
+        )
+
+    model_config = MiniGPTConfig.from_dict(config_dict)
+    model_config.vocab_size = vocab_size
+
+    model = MiniGPT(model_config)
+    state_dict = checkpoint.get("model_state_dict") or checkpoint
+    model.load_state_dict(state_dict)
+    model.to(device)
+    model.eval()
+    return model
+
+
+def _load_tokenizer(tokenizer_path: Path) -> BPETokenizer:
+    tokenizer = BPETokenizer()
+    tokenizer.load(str(tokenizer_path))
+    return tokenizer
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run the built-in benchmark suite on a saved Mini-LLM checkpoint.",
+    )
+    parser.add_argument(
+        "--checkpoint",
+        required=True,
+        help="Path to the checkpoint file produced by scripts/train.py",
+    )
+    parser.add_argument(
+        "--tokenizer",
+        help="Path to tokenizer.pkl. Defaults to the file next to the checkpoint.",
+    )
+    parser.add_argument(
+        "--device",
+        default="auto",
+        help="Computation device identifier. Defaults to auto-detection.",
+    )
+    parser.add_argument(
+        "--tasks",
+        nargs="*",
+        default=DEFAULT_TASKS,
+        help=(
+            "Benchmark task names. If omitted, uses the default suite: "
+            + ", ".join(DEFAULT_TASKS)
+        ),
+    )
+    parser.add_argument(
+        "--max-samples",
+        type=int,
+        default=256,
+        help="Maximum samples per task. Defaults to 256.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=4,
+        help="Batch size for perplexity-style tasks. Defaults to 4.",
+    )
+    parser.add_argument(
+        "--max-length",
+        type=int,
+        default=None,
+        help="Optional override for sequence length. Defaults to task-specific values.",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        default=None,
+        help="Where to cache downloaded datasets. Defaults to data/eval/benchmarks.",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Optional path to write JSON results. Defaults to checkpoint directory.",
+    )
+    parser.add_argument(
+        "--disable-auto-download",
+        action="store_true",
+        help="Disable automatic dataset downloads (reuse existing cache only).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    checkpoint_path = Path(args.checkpoint).expanduser().resolve()
+    if not checkpoint_path.exists():
+        raise FileNotFoundError(f"未找到 checkpoint 文件: {checkpoint_path}")
+
+    tokenizer_path = (
+        Path(args.tokenizer).expanduser().resolve()
+        if args.tokenizer
+        else checkpoint_path.with_name("tokenizer.pkl")
+    )
+    if not tokenizer_path.exists():
+        raise FileNotFoundError(
+            "未找到分词器文件。请通过 --tokenizer 指定 tokenizer.pkl，或确保其与 checkpoint 位于同一目录。"
+        )
+
+    device = _resolve_device(args.device)
+    print(f"🖥️  使用设备: {device}")
+
+    tokenizer = _load_tokenizer(tokenizer_path)
+    print(f"🔤 已加载分词器 (vocab_size={tokenizer.vocab_size})")
+
+    model = _load_model(checkpoint_path, device=device, vocab_size=tokenizer.vocab_size)
+    total_params = sum(p.numel() for p in model.parameters())
+    print(f"🧠 模型已加载，参数量: {total_params:,}")
+
+    cache_dir = Path(args.cache_dir).expanduser().resolve() if args.cache_dir else DEFAULT_CACHE_DIR
+    os.makedirs(cache_dir, exist_ok=True)
+
+    tasks = args.tasks or DEFAULT_TASKS
+    settings = BenchmarkSettings.from_task_names(
+        tasks,
+        frequency=1,
+        max_samples=args.max_samples,
+        batch_size=args.batch_size,
+        max_length=args.max_length,
+        overrides=None,
+        cache_dir=str(cache_dir),
+        auto_download=not args.disable_auto_download,
+    )
+
+    evaluator = BenchmarkEvaluator(device=device, tokenizer=tokenizer, settings=settings)
+    monitor = ConsoleBenchmarkLogger()
+
+    print("🚀 开始执行行业评测...")
+    metrics = evaluator.maybe_run(model, step=1, monitor=monitor, force=True)
+
+    if not metrics:
+        print("⚠️  未得到任何评测结果，请检查数据集是否可用或任务配置是否正确。")
+        return
+
+    timestamp = time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime())
+    output_path = (
+        Path(args.output).expanduser().resolve()
+        if args.output
+        else checkpoint_path.parent / f"benchmark_results_{timestamp.replace(':', '')}.json"
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    payload: dict[str, Any] = {
+        "timestamp": timestamp,
+        "checkpoint": str(checkpoint_path),
+        "tokenizer": str(tokenizer_path),
+        "device": str(device),
+        "tasks": list(metrics.keys()),
+        "metrics": metrics,
+        "settings": {
+            "max_samples": args.max_samples,
+            "batch_size": args.batch_size,
+            "max_length": args.max_length,
+            "cache_dir": str(cache_dir),
+            "auto_download": not args.disable_auto_download,
+        },
+    }
+    model_config = getattr(model, "config", None)
+    if model_config is not None and hasattr(model_config, "to_dict"):
+        payload["model_config"] = model_config.to_dict()
+
+    with open(output_path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2)
+
+    print(f"✅ 评测完成，结果已保存到: {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/run_benchmark_eval.py` to load a checkpoint, tokenizer, and run the built-in benchmark suite with sensible defaults
- document the one-command benchmark workflow in the README with pointers to key options

## Testing
- uv run python scripts/run_benchmark_eval.py --help

------
https://chatgpt.com/codex/tasks/task_e_68f5c315f3408330b7f20acfaf82b3fa