### PR TITLE
Fix cached language modeling dataset initialization

### DIFF
--- a/config/training_config.py
+++ b/config/training_config.py
@@ -271,6 +271,14 @@ class BaseConfig:
         )
         if self.pretokenize_workers < 1:
             self.pretokenize_workers = 1
+        initial_steps_env = os.environ.get("MINIGPT_INITIAL_PRETOKENIZE_STEPS", "16")
+        try:
+            self.initial_pretokenize_steps = max(0, int(initial_steps_env))
+        except (TypeError, ValueError):
+            self.initial_pretokenize_steps = 16
+        self.background_pretokenize_lm = (
+            os.environ.get("MINIGPT_BACKGROUND_PRETOKENIZE", "1") == "1"
+        )
 
         # 训练后回归评估配置
         self.regression_eval_enabled = os.environ.get("MINIGPT_REGRESSION_EVAL", "1") == "1"

--- a/src/training/datasets/language_modeling.py
+++ b/src/training/datasets/language_modeling.py
@@ -6,6 +6,7 @@ import concurrent.futures
 import hashlib
 import os
 import pickle
+import threading
 import time
 import tempfile
 from multiprocessing import get_context
@@ -75,36 +76,83 @@ class LanguageModelingDataset(Dataset):
         *,
         pretokenize: bool = True,
         pretokenize_workers: int | None = None,
+        initial_pretokenize_items: int | None = None,
+        background_pretokenize: bool = True,
     ):
         self.tokenizer = tokenizer
         self.max_length = max_length
         self.pretokenize = pretokenize
         self._explicit_worker_count = pretokenize_workers
+        self._initial_target = initial_pretokenize_items
+        self._background_enabled = background_pretokenize
+
+        self._tokens: np.ndarray | np.memmap | None = None
+        self._ready_mask: np.ndarray | np.memmap | None = None
+        self._token_cache_path: str | None = None
+        self._token_tmp_path: str | None = None
+        self._ready_cache_path: str | None = None
+        self._ready_tmp_path: str | None = None
+        self._background_thread: threading.Thread | None = None
+        self._background_error: BaseException | None = None
+        self._total_texts: int = 0
 
         if pretokenize:
             text_list = list(texts)
+            self._total_texts = len(text_list)
             cache_path = self._build_cache_path(text_list)
-            cached_tokens = self._load_cached_tokens(cache_path, len(text_list))
+            cached_tokens, cached_ready = self._load_cached_tokens(
+                cache_path, len(text_list)
+            )
             if cached_tokens is not None:
+                self._token_cache_path = cache_path
+                self._ready_cache_path = self._ready_cache_filename(cache_path)
                 self._tokens = cached_tokens
+                self._ready_mask = cached_ready
+                self.texts: list[str] | None = None
             else:
-                self._tokens = self._pretokenize_texts(text_list, cache_path=cache_path)
-            self.texts: list[str] | None = None
+                self.texts = text_list
+                self._token_cache_path = cache_path
+                self._ready_cache_path = (
+                    self._ready_cache_filename(cache_path) if cache_path else None
+                )
+                self._tokens = self._pretokenize_incremental(text_list)
         else:
             self.texts = list(texts)
             self._tokens = None
-        total = len(self._tokens) if self._tokens is not None else len(self.texts)
+            self._total_texts = len(self.texts)
+        if self._tokens is not None and not self._total_texts:
+            self._total_texts = self._tokens.shape[0]
+        total = self._total_texts
         print(f"📊 数据集初始化: {total} 条文本, 最大长度: {max_length}")
 
     def __len__(self) -> int:
-        if self._tokens is not None:
-            return self._tokens.shape[0]
-        return len(self.texts) if self.texts is not None else 0
+        return self._total_texts
 
     def __getitem__(self, idx: int) -> torch.Tensor:
+        self._check_background_status()
+
         if self._tokens is not None:
-            return torch.from_numpy(self._tokens[idx])
-        return self._encode_to_tensor(self.texts[idx], idx)
+            tokens = self._ensure_token_buffer()
+            ready = self._ensure_ready_buffer()
+            if ready is not None and ready[idx]:
+                return torch.from_numpy(tokens[idx])
+
+        if self.texts is None:
+            # Fallback when texts are unavailable but tokens missing (should be rare)
+            tokens = self._ensure_token_buffer()
+            return torch.from_numpy(tokens[idx])
+
+        tensor = self._encode_to_tensor(self.texts[idx], idx)
+
+        if self._tokens is not None:
+            tokens = self._ensure_token_buffer()
+            ready = self._ensure_ready_buffer()
+            tokens[idx] = tensor.numpy()
+            if ready is not None:
+                ready[idx] = 1
+                self._flush_ready_if_needed()
+            self._flush_tokens_if_needed()
+        return tensor
 
     def _resolve_worker_count(self, total: int) -> int:
         if total <= 1:
@@ -124,76 +172,204 @@ class LanguageModelingDataset(Dataset):
 
         return min(requested, total)
 
-    def _pretokenize_texts(
-        self, texts: list[str], *, cache_path: str | None = None
-    ) -> np.ndarray:
+    def _pretokenize_incremental(self, texts: list[str]) -> np.ndarray | np.memmap:
         total = len(texts)
-        tokens, tmp_path = self._prepare_token_buffer(total, cache_path)
-        start_time = time.time()
+        if not self._total_texts:
+            self._total_texts = total
+        tokens, tmp_path = self._prepare_token_buffer(total, self._token_cache_path)
+        ready, ready_tmp = self._prepare_ready_buffer(total, self._ready_cache_path)
+        self._token_tmp_path = tmp_path
+        self._ready_tmp_path = ready_tmp
+        self._tokens = tokens
+        self._ready_mask = ready
 
         worker_count = self._resolve_worker_count(total)
         mode_desc = (
             f" (并行 {worker_count} workers)" if worker_count > 1 else " (单线程)"
         )
-        print(f"  🔄 开始预编码 {total:,} 个样本...{mode_desc}")
 
+        start = time.time()
+        target = self._resolve_initial_target(total)
+        if target <= 0:
+            target = min(total, 1)
+
+        print(
+            f"  🔄 初始预编码 {target:,}/{total:,} 个样本...{mode_desc}"
+        )
+        self._pretokenize_range(0, target, texts, worker_count, start)
+        self._flush_tokens_if_needed()
+        self._flush_ready_if_needed()
+
+        if target >= total:
+            elapsed = time.time() - start
+            speed = total / elapsed if elapsed > 0 else 0.0
+            print(
+                f"  ✅ 预编码完成: {total:,} 样本, 耗时 {elapsed:.1f}s, 平均速度 {speed:.1f}/s"
+            )
+            self._finalize_cache()
+            self.texts = None
+            return self._ensure_token_buffer()
+
+        if self._background_enabled:
+            self._background_thread = threading.Thread(
+                target=self._background_worker,
+                args=(target, texts, worker_count, start),
+                name="LMBackgroundPretokenize",
+                daemon=True,
+            )
+            self._background_thread.start()
+
+        return self._ensure_token_buffer()
+
+    def _background_worker(
+        self,
+        start_index: int,
+        texts: list[str],
+        worker_count: int,
+        start_time: float,
+    ) -> None:
         try:
-            if worker_count <= 1:
-                self._pretokenize_texts_single(texts, tokens, start_time)
-            else:
-                try:
-                    serialized_tokenizer = pickle.dumps(self.tokenizer)
-                except Exception as exc:  # pragma: no cover - defensive fallback
-                    print(
-                        f"  ⚠️ 无法序列化tokenizer以进行并行预编码: {exc}，回退到单线程模式。"
-                    )
-                    self._pretokenize_texts_single(texts, tokens, start_time)
-                else:
-                    mp_ctx = get_context("spawn")
-                    with concurrent.futures.ProcessPoolExecutor(
-                        max_workers=worker_count,
-                        mp_context=mp_ctx,
-                        initializer=_init_pretokenize_worker,
-                        initargs=(serialized_tokenizer, self.max_length),
-                    ) as executor:
-                        chunk_hint = max(1, min(64, total // max(worker_count, 1)))
-                        result_iter = executor.map(
-                            _worker_encode,
-                            enumerate(texts),
-                            chunksize=chunk_hint,
-                        )
-                        for completed, (idx, encoded) in enumerate(result_iter, start=1):
-                            tokens[idx] = encoded
-                            if completed % 5000 == 0 or completed == total:
-                                elapsed = time.time() - start_time
-                                speed = completed / elapsed if elapsed > 0 else 0.0
-                                eta = (total - completed) / speed if speed > 0 else 0
-                                print(
-                                    f"  🔄 预编码 {completed:,}/{total:,} 样本 (速度 {speed:.1f}/s, 预计剩余 {eta/60:.1f}分钟)"
-                                )
-        except Exception:
-            self._cleanup_tmp_cache(tmp_path)
-            raise
+            total = len(texts)
+            self._pretokenize_range(start_index, total, texts, worker_count, start_time)
+            self._flush_tokens_if_needed()
+            self._flush_ready_if_needed()
+            self._finalize_cache()
+            elapsed = time.time() - start_time
+            avg_speed = total / elapsed if elapsed > 0 else 0.0
+            print(
+                f"  ✅ 后台预编码完成: {total:,} 样本, 总耗时 {elapsed:.1f}s, 平均速度 {avg_speed:.1f}/s"
+            )
+            self.texts = None
+        except BaseException as exc:  # pragma: no cover - defensive guard
+            self._background_error = exc
+            print(f"  ❌ 后台预编码失败: {exc}")
 
+    def _resolve_initial_target(self, total: int) -> int:
+        if self._initial_target is None:
+            return total
+        return max(0, min(total, self._initial_target))
+
+    def _pretokenize_range(
+        self,
+        start_idx: int,
+        end_idx: int,
+        texts: list[str],
+        worker_count: int,
+        start_time: float,
+    ) -> None:
+        total = end_idx - start_idx
+        if total <= 0:
+            return
+
+        tokens = self._ensure_token_buffer()
+        ready = self._ensure_ready_buffer()
+
+        total_texts = len(texts)
+
+        if worker_count <= 1 or total < worker_count:
+            for offset, text in enumerate(texts[start_idx:end_idx]):
+                idx = start_idx + offset
+                tokens[idx] = self._encode_numpy(text)
+                if ready is not None:
+                    ready[idx] = 1
+                processed = idx + 1
+                if ((processed) % 5000 == 0) or processed == total_texts:
+                    self._log_progress(processed, total_texts, start_time)
+        else:
+            try:
+                serialized_tokenizer = pickle.dumps(self.tokenizer)
+            except Exception as exc:  # pragma: no cover - defensive fallback
+                print(
+                    f"  ⚠️ 无法序列化tokenizer以进行并行预编码: {exc}，回退到单线程模式。"
+                )
+                self._pretokenize_range(start_idx, end_idx, texts, 1, start_time)
+                return
+
+            mp_ctx = get_context("spawn")
+            with concurrent.futures.ProcessPoolExecutor(
+                max_workers=worker_count,
+                mp_context=mp_ctx,
+                initializer=_init_pretokenize_worker,
+                initargs=(serialized_tokenizer, self.max_length),
+            ) as executor:
+                chunk_hint = max(1, min(64, total // max(worker_count, 1)))
+                enumerated = (
+                    (start_idx + i, text)
+                    for i, text in enumerate(texts[start_idx:end_idx])
+                )
+                result_iter = executor.map(
+                    _worker_encode,
+                    enumerated,
+                    chunksize=chunk_hint,
+                )
+                processed = start_idx
+                for idx, encoded in result_iter:
+                    tokens[idx] = encoded
+                    if ready is not None:
+                        ready[idx] = 1
+                    processed += 1
+                    if (processed % 5000 == 0) or processed == total_texts:
+                        self._log_progress(processed, total_texts, start_time)
+
+        if end_idx < total_texts and ((end_idx % 5000) != 0):
+            self._log_progress(end_idx, total_texts, start_time)
+
+    def _log_progress(self, processed: int, total: int, start_time: float) -> None:
         elapsed = time.time() - start_time
-        avg_speed = total / elapsed if elapsed > 0 else 0.0
-        print(f"  ✅ 预编码完成: {total:,} 样本, 耗时 {elapsed:.1f}s, 平均速度 {avg_speed:.1f}/s")
+        speed = processed / elapsed if elapsed > 0 else 0.0
+        remaining = max(0, total - processed)
+        eta = remaining / speed if speed > 0 else 0.0
+        print(
+            f"  🔄 预编码 {processed:,}/{total:,} 样本 (速度 {speed:.1f}/s, 预计剩余 {eta/60:.1f}分钟)"
+        )
 
-        if cache_path and tmp_path:
-            # ``np.memmap`` needs to be explicitly flushed and closed before renaming.
-            if isinstance(tokens, np.memmap):
-                tokens.flush()
-            del tokens
-            os.replace(tmp_path, cache_path)
-            print(f"  💾 已缓存预编码结果: {cache_path}")
-            return np.memmap(
-                cache_path,
+    def _ensure_token_buffer(self) -> np.ndarray | np.memmap:
+        if self._tokens is not None:
+            return self._tokens
+
+        shape = (self._total_texts, self.max_length)
+        if self._token_cache_path and os.path.exists(self._token_cache_path):
+            self._tokens = np.memmap(
+                self._token_cache_path,
                 dtype=np.int64,
                 mode="r+",
-                shape=(total, self.max_length),
+                shape=shape,
             )
+            return self._tokens
+        if self._token_tmp_path and os.path.exists(self._token_tmp_path):
+            self._tokens = np.memmap(
+                self._token_tmp_path,
+                dtype=np.int64,
+                mode="r+",
+                shape=shape,
+            )
+            return self._tokens
+        raise RuntimeError("预编码token缓冲未初始化")
 
-        return tokens
+    def _ensure_ready_buffer(self) -> np.ndarray | np.memmap | None:
+        if self._ready_mask is None:
+            return None
+        if isinstance(self._ready_mask, np.ndarray):
+            return self._ready_mask
+
+        shape = (self._total_texts,)
+        if self._ready_cache_path and os.path.exists(self._ready_cache_path):
+            self._ready_mask = np.memmap(
+                self._ready_cache_path,
+                dtype=np.uint8,
+                mode="r+",
+                shape=shape,
+            )
+            return self._ready_mask
+        if self._ready_tmp_path and os.path.exists(self._ready_tmp_path):
+            self._ready_mask = np.memmap(
+                self._ready_tmp_path,
+                dtype=np.uint8,
+                mode="r+",
+                shape=shape,
+            )
+            return self._ready_mask
+        return None
 
     def _pretokenize_texts_single(
         self, texts: list[str], tokens: np.ndarray, start_time: float
@@ -233,6 +409,24 @@ class LanguageModelingDataset(Dataset):
             tmp_path, dtype=np.int64, mode="w+", shape=(total, self.max_length)
         )
         return token_buffer, tmp_path
+
+    def _prepare_ready_buffer(
+        self, total: int, cache_path: str | None
+    ) -> tuple[np.ndarray | np.memmap, str | None]:
+        if not cache_path:
+            return np.zeros(total, dtype=np.uint8), None
+
+        cache_dir = os.path.dirname(cache_path)
+        try:
+            os.makedirs(cache_dir, exist_ok=True)
+        except OSError as exc:  # pragma: no cover - filesystem errors
+            print(f"  ⚠️ 无法创建缓存目录 {cache_dir}: {exc}，跳过缓存。")
+            return np.zeros(total, dtype=np.uint8), None
+
+        fd, tmp_path = tempfile.mkstemp(prefix="ready-", suffix=".npy", dir=cache_dir)
+        os.close(fd)
+        ready_buffer = np.memmap(tmp_path, dtype=np.uint8, mode="w+", shape=(total,))
+        return ready_buffer, tmp_path
 
     def _cleanup_tmp_cache(self, tmp_path: str | None) -> None:
         if not tmp_path:
@@ -292,36 +486,60 @@ class LanguageModelingDataset(Dataset):
         cache_key = hasher.hexdigest()
         return os.path.join(cache_dir, f"{cache_key}.npy")
 
+    def _ready_cache_filename(self, cache_path: str | None) -> str | None:
+        if not cache_path:
+            return None
+        return f"{cache_path}.ready"
+
     def _load_cached_tokens(
         self, cache_path: str | None, expected_rows: int
-    ) -> np.ndarray | None:
+    ) -> tuple[np.ndarray | np.memmap | None, np.ndarray | np.memmap | None]:
         if not cache_path or not os.path.exists(cache_path):
-            return None
+            return None, None
 
         try:
-            cached = np.load(cache_path, allow_pickle=False)
+            cached = np.load(cache_path, allow_pickle=False, mmap_mode="r+")
         except Exception as exc:  # pragma: no cover - depends on external state
             print(f"  ⚠️ 无法从缓存加载 {cache_path}: {exc}，重新预编码。")
-            return None
+            return None, None
 
         if not isinstance(cached, np.ndarray):
             print(f"  ⚠️ 缓存文件 {cache_path} 非数组格式，重新预编码。")
-            return None
+            return None, None
 
         if cached.dtype != np.int64:
             print(f"  ⚠️ 缓存文件 {cache_path} dtype 不匹配，重新预编码。")
-            return None
+            return None, None
 
         if cached.ndim != 2 or cached.shape[1] != self.max_length:
             print(f"  ⚠️ 缓存文件 {cache_path} 形状不匹配，重新预编码。")
-            return None
+            return None, None
 
         if cached.shape[0] != expected_rows:
             print(f"  ⚠️ 缓存文件 {cache_path} 行数不一致，重新预编码。")
-            return None
+            return None, None
 
+        ready_path = self._ready_cache_filename(cache_path)
+        ready_mask: np.ndarray | np.memmap | None = None
+        if ready_path and os.path.exists(ready_path):
+            try:
+                ready_mask = np.memmap(
+                    ready_path,
+                    dtype=np.uint8,
+                    mode="r+",
+                    shape=(expected_rows,),
+                )
+            except Exception as exc:  # pragma: no cover - filesystem/environment specific
+                print(
+                    f"  ⚠️ 无法从缓存加载就绪掩码 {ready_path}: {exc}，将重置为全部可用。"
+                )
+                ready_mask = np.ones(expected_rows, dtype=np.uint8)
+        else:
+            ready_mask = np.ones(expected_rows, dtype=np.uint8)
+
+        self._total_texts = expected_rows
         print(f"  💾 从缓存加载预编码数据: {cache_path}")
-        return cached
+        return cached, ready_mask
 
     def _save_tokens_to_cache(
         self, cache_path: str | None, tokens: np.ndarray
@@ -351,4 +569,67 @@ class LanguageModelingDataset(Dataset):
                     pass
         else:
             print(f"  💾 已缓存预编码结果: {cache_path}")
+
+    def _flush_tokens_if_needed(self) -> None:
+        if isinstance(self._tokens, np.memmap):
+            self._tokens.flush()
+
+    def _flush_ready_if_needed(self) -> None:
+        if isinstance(self._ready_mask, np.memmap):
+            self._ready_mask.flush()
+
+    def _finalize_cache(self) -> None:
+        if not self._token_cache_path or not self._token_tmp_path:
+            return
+
+        tokens = self._ensure_token_buffer()
+        ready = self._ensure_ready_buffer()
+        if isinstance(tokens, np.memmap):
+            tokens.flush()
+        if isinstance(ready, np.memmap):
+            ready.flush()
+
+        os.replace(self._token_tmp_path, self._token_cache_path)
+        self._token_tmp_path = None
+        if self._ready_tmp_path and self._ready_cache_path:
+            os.replace(self._ready_tmp_path, self._ready_cache_path)
+            self._ready_tmp_path = None
+
+        self._tokens = np.memmap(
+            self._token_cache_path,
+            dtype=np.int64,
+            mode="r+",
+            shape=(self._total_texts, self.max_length),
+        )
+        if self._ready_cache_path:
+            self._ready_mask = np.memmap(
+                self._ready_cache_path,
+                dtype=np.uint8,
+                mode="r+",
+                shape=(self._total_texts,),
+            )
+        else:
+            self._ready_mask = np.ones(self._total_texts, dtype=np.uint8)
+
+    def _check_background_status(self) -> None:
+        if self._background_error is not None:
+            raise RuntimeError("后台预编码失败") from self._background_error
+
+    def __getstate__(self) -> dict[str, Any]:
+        state = self.__dict__.copy()
+        # ``np.memmap`` and threads are not picklable; reopen lazily in workers
+        state["_tokens"] = None
+        state["_ready_mask"] = None
+        state["_background_thread"] = None
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:  # pragma: no cover - pickling path
+        self.__dict__.update(state)
+        if self.pretokenize:
+            try:
+                self._tokens = self._ensure_token_buffer()
+            except RuntimeError:
+                self._tokens = None
+            if self._ready_cache_path or self._ready_tmp_path:
+                self._ready_mask = self._ensure_ready_buffer()
 

--- a/src/training/training_monitor.py
+++ b/src/training/training_monitor.py
@@ -15,7 +15,6 @@ import matplotlib.animation as animation
 import matplotlib.pyplot as plt
 import numpy as np
 import psutil
-import seaborn as sns
 import torch
 import torch.nn as nn
 from torch.utils.tensorboard import SummaryWriter
@@ -234,13 +233,20 @@ class RealTimeVisualizer:
         self.metrics_history = deque(maxlen=max_points)
 
         # 设置绘图样式
-        plt.style.use("seaborn-v0_8")
-        sns.set_palette("husl")
+        self._configure_style()
 
         # 创建图形
         self.fig = None
         self.axes = None
         self.animation = None
+
+    def _configure_style(self) -> None:
+        """根据运行环境配置绘图样式."""
+
+        try:
+            plt.style.use("seaborn-v0_8")
+        except OSError:
+            plt.style.use("default")
 
     def start_real_time_plot(self):
         """启动实时绘图"""


### PR DESCRIPTION
## Summary
- ensure the language modeling dataset records its total sample count before incremental pretokenization writes caches
- reopen cached token and ready-mask files via memmap so dataloader workers can restore state without recomputing
- normalize the dataset length logic to rely on the cached total and always provide a valid ready mask when loading from disk

## Testing
- pytest *(skipped: PyTorch not available in the environment)*
- python -m compileall src/training/datasets/language_modeling.py

------
https://chatgpt.com/codex/tasks/task_e_68f729c5ed848330aedfb91fc50004d6