### PR TITLE
Switch pretrain manifest to pretrain_hq

### DIFF
--- a/configs/data/pretrain_manifest.json
+++ b/configs/data/pretrain_manifest.json
@@ -1,24 +1,12 @@
 {
   "type": "pretrain",
-  "total_target_tokens": 2300000000.0,
+  "total_target_tokens": 600000000.0,
   "datasets": [
-    {
-      "name": "wiki_zh",
-      "path": "data/final/wiki_zh_full.simdedup.jsonl",
-      "target_tokens": 900000000.0,
-      "weight": 0.391304
-    },
-    {
-      "name": "chinacorpus",
-      "path": "data/final/chinacorpus_full.simdedup.jsonl",
-      "target_tokens": 800000000.0,
-      "weight": 0.347826
-    },
     {
       "name": "pretrain_hq",
       "path": "data/final/pretrain_hq.cleaned.jsonl",
       "target_tokens": 600000000.0,
-      "weight": 0.26087
+      "weight": 1.0
     }
   ]
 }


### PR DESCRIPTION
## Summary
- point the pretrain manifest to the pretrain_hq dataset
- update the target token count to match the pretrain_hq corpus

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f74834c4ec83308eae79575a281028