### PR TITLE
Raise LM pretokenization warmup to 200 steps

### DIFF
--- a/config/training_config.py
+++ b/config/training_config.py
@@ -271,11 +271,11 @@ class BaseConfig:
         )
         if self.pretokenize_workers < 1:
             self.pretokenize_workers = 1
-        initial_steps_env = os.environ.get("MINIGPT_INITIAL_PRETOKENIZE_STEPS", "16")
+        initial_steps_env = os.environ.get("MINIGPT_INITIAL_PRETOKENIZE_STEPS", "200")
         try:
             self.initial_pretokenize_steps = max(0, int(initial_steps_env))
         except (TypeError, ValueError):
-            self.initial_pretokenize_steps = 16
+            self.initial_pretokenize_steps = 200
         self.background_pretokenize_lm = (
             os.environ.get("MINIGPT_BACKGROUND_PRETOKENIZE", "1") == "1"
         )


### PR DESCRIPTION
## Summary
- increase the default `MINIGPT_INITIAL_PRETOKENIZE_STEPS` to 200 so pretraining runs start with a larger pool of ready batches before falling back to background encoding

## Testing
- pytest tests/test_language_modeling_dataset.py

------
https://chatgpt.com/codex/tasks/task_e_68f7599c415c8330952f51fb10c74c06