### PR TITLE
Adjust pretokenization default steps to 100

### DIFF
--- a/config/training_config.py
+++ b/config/training_config.py
@@ -271,11 +271,11 @@ class BaseConfig:
         )
         if self.pretokenize_workers < 1:
             self.pretokenize_workers = 1
-        initial_steps_env = os.environ.get("MINIGPT_INITIAL_PRETOKENIZE_STEPS", "200")
+        initial_steps_env = os.environ.get("MINIGPT_INITIAL_PRETOKENIZE_STEPS", "100")
         try:
             self.initial_pretokenize_steps = max(0, int(initial_steps_env))
         except (TypeError, ValueError):
-            self.initial_pretokenize_steps = 200
+            self.initial_pretokenize_steps = 100
         self.background_pretokenize_lm = (
             os.environ.get("MINIGPT_BACKGROUND_PRETOKENIZE", "1") == "1"
         )


### PR DESCRIPTION
## Summary
- update the default value for `MINIGPT_INITIAL_PRETOKENIZE_STEPS` to 100
- ensure the fallback when parsing fails also uses 100 steps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f77017d5108330a07ed70aa0beb860