### PR TITLE
Adjust default pretokenize steps

### DIFF
--- a/config/training_config.py
+++ b/config/training_config.py
@@ -271,11 +271,11 @@ class BaseConfig:
         )
         if self.pretokenize_workers < 1:
             self.pretokenize_workers = 1
-        initial_steps_env = os.environ.get("MINIGPT_INITIAL_PRETOKENIZE_STEPS", "100")
+        initial_steps_env = os.environ.get("MINIGPT_INITIAL_PRETOKENIZE_STEPS", "50")
         try:
             self.initial_pretokenize_steps = max(0, int(initial_steps_env))
         except (TypeError, ValueError):
-            self.initial_pretokenize_steps = 100
+            self.initial_pretokenize_steps = 50
         self.background_pretokenize_lm = (
             os.environ.get("MINIGPT_BACKGROUND_PRETOKENIZE", "1") == "1"
         )


### PR DESCRIPTION
## Summary
- update the default initial pretokenization step count to 50 to reduce upfront processing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f77288604c8330841de1091971ea18