### PR TITLE
Disable tokenizer parallelism warning

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,14 @@
-"""
-MiniGPT 源代码包
-"""
+"""Project package initialisation for :mod:`mini-llm`."""
+
+from __future__ import annotations
+
+import os
+
+# NOTE: HuggingFace tokenizers spawn worker pools that do not interact well with
+# the fork semantics used in some of our multiprocessing utilities.  When a
+# tokenizer instance is created before a process fork happens, the default
+# behaviour is to emit a noisy warning about parallelism being disabled.  We
+# avoid the warning – and the associated risk of a deadlock – by explicitly
+# disabling tokenizers parallelism globally.  The environment variable must be
+# set before any tokenizer code is imported, so we do it at package import time.
+os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")


### PR DESCRIPTION
## Summary
- set TOKENIZERS_PARALLELISM to false during package import to avoid fork-related warnings from Hugging Face tokenizers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f86cec3c64833095ba03e2d688ad7a