### PR TITLE
Normalize tokenizer config metadata for portability

### DIFF
--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -18,6 +18,7 @@ sys.path.append(os.path.join(project_root, "src"))
 
 from model.transformer import create_model
 from tokenizer.bpe_tokenizer import BPETokenizer
+from tokenizer.config_utils import canonicalize_tokenizer_config
 
 
 class MiniGPTInference:
@@ -71,9 +72,10 @@ class MiniGPTInference:
         tokenizer = BPETokenizer(vocab_size=vocab_size)
         tokenizer.load(tokenizer_path)
 
-        expected_config = checkpoint.get("tokenizer_config")
+        raw_expected_config = checkpoint.get("tokenizer_config")
+        expected_config = canonicalize_tokenizer_config(raw_expected_config)
         if expected_config:
-            actual_config = tokenizer.get_config()
+            actual_config = canonicalize_tokenizer_config(tokenizer.get_config())
             mismatches = {
                 key: (expected_config[key], actual_config.get(key))
                 for key in expected_config

--- a/scripts/tokenizer_diagnostics.py
+++ b/scripts/tokenizer_diagnostics.py
@@ -23,6 +23,7 @@ sys.path.append(PROJECT_ROOT)
 sys.path.append(os.path.join(PROJECT_ROOT, "src"))
 
 from tokenizer.bpe_tokenizer import BPETokenizer  # noqa: E402
+from tokenizer.config_utils import canonicalize_tokenizer_config  # noqa: E402
 
 try:
     import torch
@@ -130,9 +131,10 @@ def main() -> None:
             raise FileNotFoundError(f"checkpoint不存在: {args.checkpoint}")
         else:
             checkpoint = torch.load(args.checkpoint, map_location="cpu", weights_only=False)
-            expected_config = checkpoint.get("tokenizer_config")
+            raw_expected_config = checkpoint.get("tokenizer_config")
+            expected_config = canonicalize_tokenizer_config(raw_expected_config)
             if expected_config:
-                actual_config = tokenizer.get_config()
+                actual_config = canonicalize_tokenizer_config(tokenizer.get_config())
                 mismatches = {
                     key: (expected_config[key], actual_config.get(key))
                     for key in expected_config

--- a/src/tokenizer/config_utils.py
+++ b/src/tokenizer/config_utils.py
@@ -1,0 +1,30 @@
+"""Utilities for working with tokenizer configuration metadata."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Mapping
+
+__all__ = ["canonicalize_tokenizer_config"]
+
+
+def canonicalize_tokenizer_config(config: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return a normalized copy of a tokenizer configuration mapping.
+
+    Checkpoints may embed tokenizer configuration dictionaries that include
+    environment-specific absolute paths (for example ``tokenizer_dir``).  These
+    fields are informative but should not participate in strict equality checks,
+    otherwise moving checkpoints between machines causes spurious mismatches.
+
+    The canonical representation removes path-sensitive keys so downstream
+    comparisons focus on semantic attributes such as vocabulary size and special
+    token definitions.
+    """
+
+    if not config:
+        return {}
+
+    sanitized: dict[str, Any] = deepcopy(dict(config))
+    sanitized.pop("tokenizer_dir", None)
+    return sanitized
+

--- a/src/training/pipeline/checkpointing.py
+++ b/src/training/pipeline/checkpointing.py
@@ -10,6 +10,8 @@ from typing import Any
 
 import torch
 
+from tokenizer.config_utils import canonicalize_tokenizer_config
+
 
 class CheckpointManager:
     """Persist and restore checkpoints with cleanup helpers."""
@@ -180,7 +182,7 @@ class CheckpointManager:
                 payload.update(
                     {
                         "tokenizer_vocab_size": tokenizer.vocab_size,
-                        "tokenizer_config": tokenizer.get_config(),
+                        "tokenizer_config": canonicalize_tokenizer_config(tokenizer.get_config()),
                         "tokenizer_checksum": tokenizer.checksum(),
                         "tokenizer_special_tokens": tokenizer.special_tokens_map(),
                     }
@@ -196,7 +198,7 @@ class CheckpointManager:
         payload = {
             "model_state_dict": model.state_dict(),
             "tokenizer_vocab_size": tokenizer.vocab_size,
-            "tokenizer_config": tokenizer.get_config(),
+            "tokenizer_config": canonicalize_tokenizer_config(tokenizer.get_config()),
             "tokenizer_checksum": tokenizer.checksum(),
             "tokenizer_special_tokens": tokenizer.special_tokens_map(),
             "config": self.config,


### PR DESCRIPTION
## Summary
- add a tokenizer config canonicalization helper that strips environment-specific paths
- use the canonicalized metadata when saving checkpoints and validating configs to avoid false mismatches

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f86f69299c8330aaa0e149ae511fd8