### PR TITLE
Fix causal masking for autoregressive attention

### DIFF
--- a/src/model/moe.py
+++ b/src/model/moe.py
@@ -476,8 +476,11 @@ def create_moe_model(
                         nn.init.zeros_(module.bias)
 
         def create_causal_mask(self, seq_len: int) -> torch.Tensor:
-            """创建因果掩码"""
-            mask = torch.tril(torch.ones(seq_len, seq_len))
+            """创建用于阻止关注未来token的因果掩码"""
+            mask = torch.zeros((seq_len, seq_len), dtype=torch.bool)
+            mask = mask.masked_fill(
+                torch.triu(torch.ones((seq_len, seq_len), dtype=torch.bool), diagonal=1), True
+            )
             return mask
 
         def forward(


### PR DESCRIPTION
## Summary
- build causal masks that explicitly forbid attending to future positions
- update grouped-query attention to accept boolean and additive masks
- align the MoE transformer variant with the corrected mask semantics

## Testing
- python -m compileall src/model/transformer.py src/model/gqa.py src/model/moe.py

------
https://chatgpt.com/codex/tasks/task_e_68f8c8af93f0833090bb4e85a7dbf4c6