### PR TITLE
Add VLM smoke tests with fallback vision stubs

### DIFF
--- a/dataset/vlm_dataset.py
+++ b/dataset/vlm_dataset.py
@@ -1,0 +1,100 @@
+"""Dataset helpers for MiniMind vision-language fine-tuning."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List
+
+import torch
+from PIL import Image
+from torch.utils.data import Dataset
+
+from model.model_vlm import MiniMindVLM
+
+
+class VLMDataset(Dataset):
+    """Simple JSONL based dataset used for VLM SFT and pre-training."""
+
+    def __init__(
+        self,
+        jsonl_path: str,
+        images_path: str,
+        tokenizer,
+        preprocess=None,
+        max_length: int = 512,
+        image_special_token: str = "@" * 196,
+    ) -> None:
+        super().__init__()
+        self.samples = self._load_data(jsonl_path)
+        self.images_path = Path(images_path)
+        self.tokenizer = tokenizer
+        self.preprocess = preprocess
+        self.max_length = max_length
+        self.image_token = image_special_token
+        self.bos_id = tokenizer("<|im_start|>assistant", add_special_tokens=False).input_ids
+        self.eos_id = tokenizer("<|im_end|>", add_special_tokens=False).input_ids
+
+    def _load_data(self, path: str) -> List[dict]:
+        samples = []
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                samples.append(json.loads(line))
+        return samples
+
+    def __len__(self) -> int:
+        return len(self.samples)
+
+    def _create_chat_prompt(self, conversations: List[dict]) -> str:
+        messages = []
+        for idx, turn in enumerate(conversations):
+            role = "user" if idx % 2 == 0 else "assistant"
+            messages.append({"role": role, "content": turn["content"].replace("<image>", self.image_token)})
+        return self.tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=False)
+
+    def _generate_loss_mask(self, input_ids: List[int]) -> List[int]:
+        loss_mask = [0] * len(input_ids)
+        i = 0
+        while i < len(input_ids):
+            if input_ids[i : i + len(self.bos_id)] == self.bos_id:
+                start = i + len(self.bos_id)
+                end = start
+                while end < len(input_ids):
+                    if input_ids[end : end + len(self.eos_id)] == self.eos_id:
+                        break
+                    end += 1
+                for j in range(start + 1, min(end + len(self.eos_id) + 1, self.max_length)):
+                    loss_mask[j] = 1
+                i = end + len(self.eos_id) if end < len(input_ids) else len(input_ids)
+            else:
+                i += 1
+        return loss_mask
+
+    def __getitem__(self, index: int):
+        sample = self.samples[index]
+        prompt = self._create_chat_prompt(sample["conversations"])
+        input_ids = self.tokenizer(prompt).input_ids[: self.max_length]
+        input_ids += [self.tokenizer.pad_token_id] * (self.max_length - len(input_ids))
+        loss_mask = self._generate_loss_mask(input_ids)
+
+        input_tensor = torch.tensor(input_ids[:-1], dtype=torch.long)
+        label_tensor = torch.tensor(input_ids[1:], dtype=torch.long)
+        mask_tensor = torch.tensor(loss_mask[1:], dtype=torch.long)
+
+        image_tensors = []
+        for image_name in sample["image"].split(","):
+            image_name = image_name.strip()
+            image_path = self.images_path / image_name
+            if not image_path.exists():
+                candidates = list(self.images_path.glob(f"**/{image_name}"))
+                if not candidates:
+                    raise FileNotFoundError(f"Image {image_name} not found under {self.images_path}")
+                image_path = candidates[0]
+            image = Image.open(image_path)
+            image_tensor = MiniMindVLM.image2tensor(image, self.preprocess)
+            image_tensors.append(image_tensor)
+        pixel_values = torch.stack(image_tensors, dim=0)
+
+        return input_tensor, label_tensor, mask_tensor, pixel_values

--- a/eval_vlm.py
+++ b/eval_vlm.py
@@ -1,0 +1,89 @@
+"""Evaluate a trained MiniMind VLM checkpoint."""
+from __future__ import annotations
+
+import argparse
+import os
+import warnings
+
+import torch
+from PIL import Image
+from transformers import AutoModelForCausalLM, AutoTokenizer, TextStreamer
+
+from model.model_vlm import MiniMindVLM, VLMConfig
+from trainer.trainer_utils import setup_seed
+
+warnings.filterwarnings('ignore')
+
+
+def init_model(args):
+    tokenizer = AutoTokenizer.from_pretrained(args.load_from)
+    if 'model' in args.load_from:
+        moe_suffix = '_moe' if args.use_moe else ''
+        ckp = f'./{args.save_dir}/{args.weight}_{args.hidden_size}{moe_suffix}.pth'
+        model = MiniMindVLM(
+            VLMConfig(hidden_size=args.hidden_size, num_hidden_layers=args.num_hidden_layers, use_moe=bool(args.use_moe)),
+            vision_model_path=args.vision_model_path,
+        )
+        state_dict = torch.load(ckp, map_location=args.device)
+        model.load_state_dict({k: v for k, v in state_dict.items() if 'mask' not in k}, strict=False)
+    else:
+        model = AutoModelForCausalLM.from_pretrained(args.load_from, trust_remote_code=True)
+        model.vision_encoder, model.processor = MiniMindVLM.get_vision_model(args.vision_model_path)
+
+    print(f'VLM模型参数: {sum(p.numel() for p in model.parameters() if p.requires_grad) / 1e6:.2f} M(illion)')
+    preprocess = model.processor
+    return model.eval().to(args.device), tokenizer, preprocess
+
+
+def main():
+    parser = argparse.ArgumentParser(description='MiniMind-V Chat')
+    parser.add_argument('--load_from', default='model', type=str, help='模型加载路径（model=原生权重，其他路径=transformers格式）')
+    parser.add_argument('--save_dir', default='out', type=str, help='模型权重目录')
+    parser.add_argument('--weight', default='sft_vlm', type=str, help='权重名称前缀（pretrain_vlm, sft_vlm）')
+    parser.add_argument('--hidden_size', default=512, type=int, help='隐藏层维度')
+    parser.add_argument('--num_hidden_layers', default=8, type=int, help='隐藏层数量')
+    parser.add_argument('--use_moe', default=0, type=int, choices=[0, 1], help='是否使用MoE架构')
+    parser.add_argument('--max_new_tokens', default=256, type=int, help='最大生成长度')
+    parser.add_argument('--temperature', default=0.65, type=float, help='生成温度')
+    parser.add_argument('--top_p', default=0.85, type=float, help='nucleus采样阈值')
+    parser.add_argument('--image_dir', default='./dataset/vlm/eval_images', type=str, help='测试图像目录')
+    parser.add_argument('--device', default='cuda' if torch.cuda.is_available() else 'cpu', type=str, help='运行设备')
+    parser.add_argument('--vision_model_path', default='./model/vision_model/clip-vit-base-patch16', type=str, help='视觉模型路径')
+    args = parser.parse_args()
+
+    model, tokenizer, preprocess = init_model(args)
+    streamer = TextStreamer(tokenizer, skip_prompt=True, skip_special_tokens=True)
+    prompt = "仔细看一下这张图：\n\n<image>\n\n描述一下这个图像的内容。"
+
+    for image_file in sorted(os.listdir(args.image_dir)):
+        if image_file.lower().endswith(('.png', '.jpg', '.jpeg', '.bmp')):
+            setup_seed(2026)
+            image_path = os.path.join(args.image_dir, image_file)
+            image = Image.open(image_path).convert('RGB')
+            pixel_values = MiniMindVLM.image2tensor(image, preprocess).to(args.device).unsqueeze(0)
+
+            messages = [{"role": "user", "content": prompt.replace('<image>', model.params.image_special_token)}]
+            inputs_text = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+            inputs = tokenizer(inputs_text, return_tensors='pt', truncation=True).to(args.device)
+
+            print(f'[图像]: {image_file}')
+            prompt_display = prompt.replace("\n", "\\n")
+            print(f'👶: {prompt_display}')
+            print('🤖️: ', end='')
+            model.generate(
+                inputs=inputs['input_ids'],
+                attention_mask=inputs['attention_mask'],
+                max_new_tokens=args.max_new_tokens,
+                do_sample=True,
+                streamer=streamer,
+                pad_token_id=tokenizer.pad_token_id,
+                eos_token_id=tokenizer.eos_token_id,
+                top_p=args.top_p,
+                temperature=args.temperature,
+                pixel_values=pixel_values,
+            )
+            print('\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/model/model_vlm.py
+++ b/model/model_vlm.py
@@ -1,0 +1,262 @@
+"""MiniMind vision-language model integration.
+
+This module adapts the MiniMind-V implementation from the upstream
+``jingyaogong/minimind-v`` project so that it can be used inside the
+Mini-LLM codebase.  Only lightweight dependencies are required and the
+vision encoder is kept frozen by default which keeps the overall
+implementation compact.
+"""
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from typing import List, Optional, Tuple, Union
+
+import numpy as np
+import torch
+from torch import nn
+from transformers import CLIPModel, CLIPProcessor
+
+from .model_minillm import MiniLLMConfig, MiniLLMForCausalLM, MOEFeedForward
+
+
+class VLMConfig(MiniLLMConfig):
+    """Configuration for the MiniMind vision-language model."""
+
+    model_type = "minimind-v"
+
+    def __init__(
+        self,
+        image_special_token: str = "@" * 196,
+        image_ids: Optional[List[int]] = None,
+        **kwargs,
+    ) -> None:
+        self.image_special_token = image_special_token
+        self.image_ids = image_ids or [34] * 196
+        super().__init__(**kwargs)
+
+
+class _FallbackProcessor:
+    """Minimal image processor used when CLIP assets are unavailable."""
+
+    def __init__(self, image_size: int = 224) -> None:
+        self.image_size = image_size
+        self.mean = torch.tensor([0.48145466, 0.4578275, 0.40821073], dtype=torch.float32).view(3, 1, 1)
+        self.std = torch.tensor([0.26862954, 0.26130258, 0.27577711], dtype=torch.float32).view(3, 1, 1)
+
+    def _prepare(self, image) -> torch.Tensor:
+        if image.mode != "RGB":
+            image = image.convert("RGB")
+        image = image.resize((self.image_size, self.image_size))
+        array = np.array(image, dtype=np.float32) / 255.0
+        tensor = torch.from_numpy(array).permute(2, 0, 1)
+        tensor = (tensor - self.mean) / self.std
+        return tensor
+
+    def __call__(self, images, return_tensors: str = "pt"):
+        if not isinstance(images, (list, tuple)):
+            images = [images]
+        tensors = [self._prepare(image) for image in images]
+        pixel_values = torch.stack(tensors, dim=0)
+        if return_tensors == "pt":
+            return {"pixel_values": pixel_values}
+        raise ValueError("_FallbackProcessor only supports return_tensors='pt'")
+
+
+class _FallbackVisionBackbone(nn.Module):
+    """Very small vision backbone producing CLIP-like patch embeddings."""
+
+    def __init__(self, embed_dim: int = 768) -> None:
+        super().__init__()
+        self.patch_embed = nn.Conv2d(3, embed_dim, kernel_size=16, stride=16, bias=False)
+        self.norm = nn.LayerNorm(embed_dim)
+        self.cls_token = nn.Parameter(torch.zeros(1, 1, embed_dim))
+
+    def forward(self, pixel_values: torch.Tensor) -> SimpleNamespace:  # type: ignore[override]
+        patches = self.patch_embed(pixel_values)
+        patches = patches.flatten(2).transpose(1, 2)
+        patches = self.norm(patches)
+        cls_token = self.cls_token.expand(pixel_values.size(0), -1, -1)
+        embeddings = torch.cat([cls_token, patches], dim=1)
+        return SimpleNamespace(last_hidden_state=embeddings)
+
+
+class _FallbackVisionEncoder(nn.Module):
+    """Wrapper mimicking the CLIP vision encoder interface."""
+
+    def __init__(self, embed_dim: int = 768) -> None:
+        super().__init__()
+        self.vision_model = _FallbackVisionBackbone(embed_dim)
+        for param in self.parameters():
+            param.requires_grad = False
+
+
+class VisionProj(nn.Module):
+    """Projects CLIP vision embeddings into the language model space."""
+
+    def __init__(self, ve_hidden_size: int = 768, hidden_size: int = 512) -> None:
+        super().__init__()
+        self.vision_proj = nn.Linear(ve_hidden_size, hidden_size)
+
+    def forward(self, image_encoders: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        return self.vision_proj(image_encoders)
+
+
+class MiniMindVLM(MiniLLMForCausalLM):
+    """MiniMind Vision-Language model with a frozen CLIP encoder."""
+
+    config_class = VLMConfig
+
+    def __init__(
+        self,
+        params: Optional[VLMConfig] = None,
+        vision_model_path: str = "./model/vision_model/clip-vit-base-patch16",
+    ) -> None:
+        params = params or VLMConfig()
+        super().__init__(params)
+        self.params: VLMConfig = params
+        self.vision_encoder, self.processor = self.get_vision_model(vision_model_path)
+        self.vision_proj = VisionProj(hidden_size=params.hidden_size)
+
+    # ------------------------------------------------------------------
+    # Vision helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def get_vision_model(model_path: str) -> Tuple[Optional[CLIPModel], Optional[CLIPProcessor]]:
+        """Load a CLIP model/processor if available on disk."""
+
+        if not os.path.exists(model_path):
+            return _FallbackVisionEncoder(), _FallbackProcessor()
+
+        model = CLIPModel.from_pretrained(model_path)
+        processor = CLIPProcessor.from_pretrained(model_path)
+        for param in model.parameters():
+            param.requires_grad = False
+        return model.eval(), processor
+
+    @staticmethod
+    def image2tensor(image, processor: Optional[CLIPProcessor]) -> torch.Tensor:
+        if processor is None:
+            raise RuntimeError("CLIP processor has not been initialised. Did you download the vision encoder?")
+        if image.mode in {"RGBA", "LA"}:
+            image = image.convert("RGB")
+        inputs = processor(images=image, return_tensors="pt")["pixel_values"]
+        return inputs
+
+    @staticmethod
+    def get_image_embeddings(image_tensors: torch.Tensor, vision_model: Optional[CLIPModel]) -> torch.Tensor:
+        if vision_model is None:
+            raise RuntimeError("CLIP vision model has not been initialised. Did you download the vision encoder?")
+        with torch.no_grad():
+            outputs = vision_model.vision_model(pixel_values=image_tensors)
+        img_embedding = outputs.last_hidden_state[:, 1:, :].squeeze()
+        return img_embedding
+
+    # ------------------------------------------------------------------
+    # Language model integration
+    # ------------------------------------------------------------------
+    def _inject_vision_embeddings(
+        self,
+        tokens: torch.Tensor,
+        hidden_states: torch.Tensor,
+        vision_tensors: Optional[torch.Tensor] = None,
+        seqlen: int = 512,
+    ) -> torch.Tensor:
+        def find_indices(tok: torch.Tensor, image_ids: List[int]):
+            image_ids_tensor = torch.tensor(image_ids, device=tok.device)
+            token_windows = tok.unfold(1, len(image_ids), 1)
+            matches = (token_windows == image_ids_tensor).all(dim=2)
+            results = {}
+            for batch_idx in range(tok.size(0)):
+                indices = matches[batch_idx].nonzero(as_tuple=True)[0]
+                if indices.numel():
+                    results[batch_idx] = [
+                        (idx.item(), idx.item() + len(image_ids) - 1) for idx in indices
+                    ]
+            return results or None
+
+        image_indices = find_indices(tokens, self.params.image_ids)
+        if vision_tensors is not None and image_indices:
+            projected = self.vision_proj(vision_tensors)
+            if projected.dim() == 3:
+                projected = projected.unsqueeze(0)
+            updated_states = []
+            for batch_idx in range(hidden_states.size(0)):
+                if batch_idx not in image_indices:
+                    updated_states.append(hidden_states[batch_idx])
+                    continue
+                current = hidden_states[batch_idx]
+                img_idx = 0
+                for start_idx, end_idx in image_indices[batch_idx]:
+                    if img_idx < projected.size(1):
+                        replacement = projected[batch_idx][img_idx]
+                        current = torch.cat((current[:start_idx], replacement, current[end_idx + 1 :]), dim=0)[:seqlen]
+                        img_idx += 1
+                updated_states.append(current)
+            hidden_states = torch.stack(updated_states, dim=0)
+        return hidden_states
+
+    def forward(
+        self,
+        input_ids: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        past_key_values: Optional[List[Tuple[torch.Tensor, torch.Tensor]]] = None,
+        use_cache: bool = False,
+        logits_to_keep: Union[int, torch.Tensor] = 0,
+        pixel_values: Optional[torch.FloatTensor] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        _, seq_length = input_ids.shape
+        if hasattr(past_key_values, "layers"):
+            past_key_values = None
+        past_key_values = past_key_values or [None] * len(self.model.layers)
+        start_pos = past_key_values[0][0].shape[1] if past_key_values[0] is not None else 0
+
+        hidden_states = self.model.dropout(self.model.embed_tokens(input_ids))
+
+        if pixel_values is not None and start_pos == 0:
+            if pixel_values.dim() == 6:
+                pixel_values = pixel_values.squeeze(2)
+            bs, num_images, _, _, _ = pixel_values.shape
+            stack_dim = 1 if bs > 1 else 0
+            vision_tensors = torch.stack(
+                [
+                    self.get_image_embeddings(pixel_values[:, idx, :, :, :], self.vision_encoder)
+                    for idx in range(num_images)
+                ],
+                dim=stack_dim,
+            )
+            hidden_states = self._inject_vision_embeddings(
+                tokens=input_ids, hidden_states=hidden_states, vision_tensors=vision_tensors, seqlen=seq_length
+            )
+
+        position_embeddings = (
+            self.model.freqs_cos[start_pos : start_pos + seq_length],
+            self.model.freqs_sin[start_pos : start_pos + seq_length],
+        )
+
+        presents: List[Tuple[torch.Tensor, torch.Tensor]] = []
+        for layer, past_key_value in zip(self.model.layers, past_key_values):
+            hidden_states, present = layer(
+                hidden_states,
+                position_embeddings,
+                past_key_value=past_key_value,
+                use_cache=use_cache,
+                attention_mask=attention_mask,
+            )
+            presents.append(present)
+
+        hidden_states = self.model.norm(hidden_states)
+        aux_loss = sum(
+            layer.mlp.aux_loss
+            for layer in self.model.layers
+            if isinstance(layer.mlp, MOEFeedForward)
+        )
+
+        slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        logits = self.lm_head(hidden_states[:, slice_indices, :])
+        self.OUT.__setitem__("last_hidden_state", hidden_states)
+        self.OUT.__setitem__("logits", logits)
+        self.OUT.__setitem__("aux_loss", aux_loss)
+        self.OUT.__setitem__("past_key_values", presents)
+        return self.OUT

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+modelscope==1.16.1
+Pillow==11.0.0
 datasets==2.21.0
 datasketch==1.6.4
 Flask==3.0.3

--- a/scripts/run_vlm_pipeline.py
+++ b/scripts/run_vlm_pipeline.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""One-click pipeline for MiniMind VLM training and evaluation.
+
+The script automates three stages:
+
+1. Download required assets from ModelScope (vision encoder, base LLM
+   checkpoints, datasets and evaluation images).
+2. Launch supervised fine-tuning for the VLM model with sensible
+   defaults that run on a single GPU.
+3. Evaluate the trained checkpoint on the bundled evaluation images.
+
+By default the script downloads the light-weight single/multi image SFT
+subset of the official ``gongjy/minimind-v_dataset`` so that the
+pipeline can run in a constrained environment.  Pass ``--download-full``
+if you would like to fetch the full dataset (this requires more than
+1GB of disk space).
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+from typing import Iterable, List
+
+
+def run_cmd(cmd: List[str], cwd: Path | None = None) -> None:
+    print(f"$ {' '.join(cmd)}")
+    subprocess.run(cmd, check=True, cwd=cwd)
+
+
+def ensure_snapshot(
+    repo_id: str,
+    repo_type: str,
+    target_dir: Path,
+    allow_patterns: Iterable[str] | None,
+    cache_dir: Path,
+    force: bool,
+) -> Path:
+    from modelscope.hub.snapshot_download import snapshot_download
+
+    if target_dir.exists() and force:
+        shutil.rmtree(target_dir)
+    if target_dir.exists() and any(target_dir.iterdir()):
+        return target_dir
+    target_dir.mkdir(parents=True, exist_ok=True)
+    snapshot_download(
+        repo_id=repo_id,
+        repo_type=repo_type,
+        cache_dir=str(cache_dir),
+        local_dir=str(target_dir),
+        allow_patterns=list(allow_patterns) if allow_patterns else None,
+    )
+    return target_dir
+
+
+def extract_zip(archive: Path, target_dir: Path) -> None:
+    if not archive.exists():
+        return
+    target_dir.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(archive, 'r') as zf:
+        zf.extractall(target_dir)
+
+
+def copy_tree(src: Path, dst: Path) -> None:
+    if not src.exists():
+        return
+    if dst.exists():
+        shutil.rmtree(dst)
+    shutil.copytree(src, dst)
+
+
+def prepare_dataset(args) -> tuple[Path, Path]:
+    dataset_root = Path('dataset/vlm')
+    download_dir = dataset_root / '_download'
+    dataset_root.mkdir(parents=True, exist_ok=True)
+
+    allow_patterns = args.allow_pattern
+    if not allow_patterns:
+        allow_patterns = [
+            'sft_vlm_data_multi.jsonl',
+            'sft_multi_images_trans_image.zip',
+            'dataset/eval_images/*',
+            'README.md',
+        ]
+        if args.download_full:
+            allow_patterns.extend([
+                'sft_data.jsonl',
+                'sft_images.zip',
+                'pretrain_data.jsonl',
+                'pretrain_images.zip',
+            ])
+
+    ensure_snapshot(
+        repo_id=args.dataset_repo,
+        repo_type='dataset',
+        target_dir=download_dir,
+        allow_patterns=allow_patterns,
+        cache_dir=args.cache_dir,
+        force=args.force,
+    )
+
+    for json_name in ('sft_data.jsonl', 'sft_vlm_data_multi.jsonl'):
+        src = download_dir / json_name
+        if src.exists():
+            shutil.copy2(src, dataset_root / json_name)
+
+    extract_zip(download_dir / 'sft_images.zip', dataset_root / 'sft_images')
+    extract_zip(download_dir / 'sft_multi_images_trans_image.zip', dataset_root / 'sft_images')
+
+    eval_src = download_dir / 'dataset' / 'eval_images'
+    if eval_src.exists():
+        copy_tree(eval_src, dataset_root / 'eval_images')
+
+    image_dir = dataset_root / 'sft_images'
+    has_jpg = any(image_dir.glob('**/*.jpg'))
+    has_png = any(image_dir.glob('**/*.png'))
+    has_jpeg = any(image_dir.glob('**/*.jpeg'))
+    if not (has_jpg or has_png or has_jpeg):
+        raise RuntimeError(
+            'No training images were extracted. Use --download-full to fetch the full dataset or provide custom patterns.'
+        )
+
+    primary_json = dataset_root / 'sft_data.jsonl'
+    if not primary_json.exists():
+        # Fall back to the smaller multi-image dataset when the full json is not downloaded.
+        primary_json = dataset_root / 'sft_vlm_data_multi.jsonl'
+        if not primary_json.exists():
+            raise RuntimeError('Could not locate an SFT json file in the downloaded dataset.')
+    return primary_json, image_dir
+
+
+def prepare_vision_encoder(args) -> Path:
+    vision_dir = Path('model/vision_model/clip-vit-base-patch16')
+    ensure_snapshot(
+        repo_id=args.vision_repo,
+        repo_type='model',
+        target_dir=vision_dir,
+        allow_patterns=None,
+        cache_dir=args.cache_dir,
+        force=args.force,
+    )
+    return vision_dir
+
+
+def prepare_base_llm(args) -> Path:
+    out_dir = Path('out')
+    out_dir.mkdir(parents=True, exist_ok=True)
+    download_dir = Path('model/_llm_download')
+    ensure_snapshot(
+        repo_id=args.model_repo,
+        repo_type='model',
+        target_dir=download_dir,
+        allow_patterns=['llm_512.pth'],
+        cache_dir=args.cache_dir,
+        force=args.force,
+    )
+    src = download_dir / 'llm_512.pth'
+    if not src.exists():
+        raise RuntimeError('The base llm_512.pth weight was not downloaded; please check the repository layout.')
+    dst = out_dir / 'pretrain_vlm_512.pth'
+    if not dst.exists() or args.force:
+        shutil.copy2(src, dst)
+    return dst
+
+
+def run_training(args, data_json: Path, image_dir: Path, vision_dir: Path) -> None:
+    train_cmd = [
+        sys.executable,
+        'trainer/train_vlm_sft.py',
+        '--epochs', str(args.epochs),
+        '--batch_size', str(args.batch_size),
+        '--learning_rate', str(args.learning_rate),
+        '--hidden_size', str(args.hidden_size),
+        '--num_hidden_layers', str(args.num_hidden_layers),
+        '--max_seq_len', str(args.max_seq_len),
+        '--data_path', str(data_json.resolve()),
+        '--images_path', str(image_dir.resolve()),
+        '--vision_model_path', str(vision_dir.resolve()),
+        '--tokenizer_path', str(Path('model').resolve()),
+        '--save_dir', str(Path('out').resolve()),
+    ]
+    if args.use_moe:
+        train_cmd.extend(['--use_moe', '1'])
+    if args.use_wandb:
+        train_cmd.append('--use_wandb')
+    run_cmd(train_cmd)
+
+
+def run_evaluation(args, vision_dir: Path) -> None:
+    eval_cmd = [
+        sys.executable,
+        'eval_vlm.py',
+        '--load_from', 'model',
+        '--save_dir', 'out',
+        '--weight', args.eval_weight,
+        '--hidden_size', str(args.hidden_size),
+        '--num_hidden_layers', str(args.num_hidden_layers),
+        '--image_dir', str(Path('dataset/vlm/eval_images').resolve()),
+        '--vision_model_path', str(vision_dir.resolve()),
+        '--max_new_tokens', str(args.eval_max_new_tokens),
+    ]
+    if args.use_moe:
+        eval_cmd.extend(['--use_moe', '1'])
+    run_cmd(eval_cmd)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='MiniMind VLM automation pipeline')
+    parser.add_argument('--dataset-repo', default='gongjy/minimind-v_dataset', help='ModelScope dataset repo id')
+    parser.add_argument('--model-repo', default='gongjy/MiniMind2-V-PyTorch', help='ModelScope base LLM repo id')
+    parser.add_argument('--vision-repo', default='openai-mirror/clip-vit-base-patch16', help='ModelScope vision encoder repo id')
+    parser.add_argument('--cache-dir', type=Path, default=Path.home() / '.cache' / 'modelscope', help='ModelScope cache directory')
+    parser.add_argument('--allow-pattern', nargs='*', help='Custom allow_patterns passed to ModelScope snapshot_download')
+    parser.add_argument('--download-full', action='store_true', help='Download the full dataset (slow and large)')
+    parser.add_argument('--force', action='store_true', help='Redownload assets even if they already exist locally')
+    parser.add_argument('--epochs', type=int, default=1, help='Number of training epochs for the demo run')
+    parser.add_argument('--batch-size', type=int, default=2, help='Batch size for the demo run')
+    parser.add_argument('--learning-rate', type=float, default=5e-6, help='Learning rate for the demo run')
+    parser.add_argument('--hidden-size', type=int, default=512, help='Hidden size of the VLM')
+    parser.add_argument('--num-hidden-layers', type=int, default=8, help='Transformer layer count')
+    parser.add_argument('--max-seq-len', type=int, default=1024, help='Maximum sequence length during training')
+    parser.add_argument('--use-moe', action='store_true', help='Enable MoE configuration for the VLM')
+    parser.add_argument('--use-wandb', action='store_true', help='Enable SwanLab/W&B logging during training')
+    parser.add_argument('--eval-weight', default='sft_vlm', help='Checkpoint prefix used during evaluation')
+    parser.add_argument('--eval-max-new-tokens', type=int, default=256, help='Maximum tokens generated during evaluation')
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    args.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    print('=== 1. Downloading assets from ModelScope ===')
+    data_json, image_dir = prepare_dataset(args)
+    vision_dir = prepare_vision_encoder(args)
+    prepare_base_llm(args)
+
+    print('=== 2. Launching training run ===')
+    run_training(args, data_json, image_dir, vision_dir)
+
+    print('=== 3. Evaluating checkpoint ===')
+    run_evaluation(args, vision_dir)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_vlm_smoke.py
+++ b/tests/test_vlm_smoke.py
@@ -1,0 +1,140 @@
+"""Smoke tests ensuring the MiniMind VLM training & inference loops run locally."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import torch
+from PIL import Image
+from torch.utils.data import DataLoader
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from dataset.vlm_dataset import VLMDataset
+from model.model_vlm import VLMConfig
+from trainer.trainer_utils import init_vlm_model
+
+
+def _create_dummy_dataset(root: Path) -> tuple[Path, Path]:
+    """Create a tiny JSONL dataset plus a single RGB image for smoke tests."""
+
+    images_dir = root / "images"
+    images_dir.mkdir(parents=True, exist_ok=True)
+    image_path = images_dir / "dummy.png"
+    Image.new("RGB", (224, 224), color=(255, 0, 0)).save(image_path)
+
+    sample = {
+        "image": image_path.name,
+        "conversations": [
+            {"content": "<image> 请描述图片里的颜色。"},
+            {"content": "图片主要是红色。"},
+        ],
+    }
+
+    data_path = root / "samples.jsonl"
+    with data_path.open("w", encoding="utf-8") as f:
+        f.write(json.dumps(sample, ensure_ascii=False) + "\n")
+
+    return data_path, images_dir
+
+
+def _init_tiny_model(tmp_path: Path):
+    """Initialise a CPU-only MiniMindVLM with extremely small settings."""
+
+    vlm_config = VLMConfig(
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        num_hidden_layers=1,
+        intermediate_size=128,
+        max_seq_len=128,
+        image_ids=[34] * 16,
+        image_special_token="@" * 16,
+    )
+
+    model, tokenizer, preprocess = init_vlm_model(
+        vlm_config,
+        from_weight="none",
+        tokenizer_path=str(Path("model")),
+        vision_model_path=str(tmp_path / "missing_vision"),
+        save_dir=str(tmp_path / "out"),
+        device="cpu",
+    )
+    return model, tokenizer, preprocess
+
+
+def test_vlm_training_smoke(tmp_path):
+    """Run a single optimisation step to validate the training loop wiring."""
+
+    data_path, images_dir = _create_dummy_dataset(tmp_path)
+    model, tokenizer, preprocess = _init_tiny_model(tmp_path)
+
+    dataset = VLMDataset(
+        str(data_path),
+        str(images_dir),
+        tokenizer,
+        preprocess,
+        max_length=96,
+        image_special_token=model.params.image_special_token,
+    )
+    loader = DataLoader(dataset, batch_size=1, shuffle=False)
+    input_ids, labels, loss_mask, pixel_values = next(iter(loader))
+
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+    criterion = torch.nn.CrossEntropyLoss(reduction="none")
+
+    model.train()
+    outputs = model(input_ids, pixel_values=pixel_values)
+    logits = outputs.logits
+
+    # Align logits and labels for next-token prediction.
+    shift_logits = logits[:, :-1, :]
+    shift_labels = labels[:, : shift_logits.size(1)]
+    shift_mask = loss_mask[:, : shift_logits.size(1)]
+
+    loss = criterion(shift_logits.reshape(-1, shift_logits.size(-1)), shift_labels.reshape(-1))
+    loss = loss.view_as(shift_labels)
+    loss = (loss * shift_mask).sum() / torch.clamp(shift_mask.sum(), min=1.0)
+
+    loss.backward()
+    optimizer.step()
+
+    assert torch.isfinite(loss), "Loss should be a finite value after one optimisation step."
+
+
+def test_vlm_inference_smoke(tmp_path):
+    """Ensure greedy decoding works and returns tokens that include the prompt."""
+
+    data_path, images_dir = _create_dummy_dataset(tmp_path)
+    model, tokenizer, preprocess = _init_tiny_model(tmp_path)
+
+    dataset = VLMDataset(
+        str(data_path),
+        str(images_dir),
+        tokenizer,
+        preprocess,
+        max_length=96,
+        image_special_token=model.params.image_special_token,
+    )
+    pixel_values = dataset[0][3].unsqueeze(0)
+
+    messages = [{"role": "user", "content": "<image> 请描述图片里的颜色。"}]
+    prompt = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+    encoded = tokenizer(prompt, return_tensors="pt")
+
+    model.eval()
+    with torch.no_grad():
+        generated = model.generate(
+            encoded["input_ids"],
+            attention_mask=encoded["attention_mask"],
+            max_new_tokens=4,
+            do_sample=False,
+            pixel_values=pixel_values,
+            pad_token_id=tokenizer.pad_token_id,
+            eos_token_id=tokenizer.eos_token_id,
+        )
+
+    assert generated.shape[1] >= encoded["input_ids"].shape[1]

--- a/trainer/train_vlm_sft.py
+++ b/trainer/train_vlm_sft.py
@@ -1,0 +1,211 @@
+import os
+import sys
+
+__package__ = "trainer"
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import argparse
+import time
+import warnings
+
+import torch
+import torch.distributed as dist
+from contextlib import nullcontext
+from torch import optim, nn
+from torch.nn.parallel import DistributedDataParallel
+from torch.utils.data import DataLoader, DistributedSampler
+
+from dataset.vlm_dataset import VLMDataset
+from model.model_vlm import VLMConfig
+from trainer.trainer_utils import (
+    SkipBatchSampler,
+    get_lr,
+    init_distributed_mode,
+    init_vlm_model,
+    is_main_process,
+    setup_seed,
+    vlm_checkpoint,
+    Logger,
+)
+
+warnings.filterwarnings('ignore')
+
+
+def train_epoch(args, vlm_config, model, optimizer, scaler, autocast_ctx, loader, epoch, iters, start_step, wandb=None):
+    loss_fct = nn.CrossEntropyLoss(reduction='none')
+    start_time = time.time()
+    model.train()
+
+    for step, (X, Y, loss_mask, pixel_values) in enumerate(loader, start=start_step + 1):
+        X = X.to(args.device)
+        Y = Y.to(args.device)
+        loss_mask = loss_mask.to(args.device)
+        pixel_values = pixel_values.to(args.device)
+
+        lr = get_lr(epoch * iters + step, args.epochs * iters, args.learning_rate)
+        for param_group in optimizer.param_groups:
+            param_group['lr'] = lr
+
+        with autocast_ctx:
+            res = model(X, pixel_values=pixel_values)
+            loss = loss_fct(
+                res.logits.view(-1, res.logits.size(-1)),
+                Y.view(-1)
+            ).view(Y.size())
+
+            loss = (loss * loss_mask).sum() / loss_mask.sum()
+            loss = (loss + res.aux_loss) / args.accumulation_steps
+
+        scaler.scale(loss).backward()
+
+        if (step + 1) % args.accumulation_steps == 0:
+            scaler.unscale_(optimizer)
+            torch.nn.utils.clip_grad_norm_(model.parameters(), args.grad_clip)
+            scaler.step(optimizer)
+            scaler.update()
+            optimizer.zero_grad(set_to_none=True)
+
+        if step % args.log_interval == 0 or step == iters - 1:
+            spend_time = time.time() - start_time
+            current_loss = loss.item() * args.accumulation_steps
+            current_lr = optimizer.param_groups[-1]['lr']
+            eta_min = spend_time / (step + 1) * iters // 60 - spend_time // 60
+            Logger(f'Epoch:[{epoch + 1}/{args.epochs}]({step}/{iters}) loss:{current_loss:.6f} lr:{current_lr:.12f} epoch_Time:{eta_min}min')
+            if wandb:
+                wandb.log({"loss": current_loss, "lr": current_lr, "epoch_Time": eta_min})
+
+        if (step % args.save_interval == 0 or step == iters - 1) and is_main_process():
+            model.eval()
+            moe_suffix = '_moe' if vlm_config.use_moe else ''
+            ckp = f'{args.save_dir}/{args.save_weight}_{vlm_config.hidden_size}{moe_suffix}.pth'
+            state_dict = model.module.state_dict() if isinstance(model, DistributedDataParallel) else model.state_dict()
+            clean_state_dict = {k: v for k, v in state_dict.items() if not k.startswith('vision_encoder.')}
+            clean_state_dict = {k: v.half() for k, v in clean_state_dict.items()}
+            torch.save(clean_state_dict, ckp)
+            vlm_checkpoint(
+                vlm_config,
+                weight=args.save_weight,
+                model=model,
+                optimizer=optimizer,
+                epoch=epoch,
+                step=step,
+                wandb=wandb,
+                save_dir='../checkpoints',
+                scaler=scaler,
+            )
+            model.train()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="MiniMind-V SFT")
+    parser.add_argument('--save_dir', type=str, default='../out', help='模型保存目录')
+    parser.add_argument('--save_weight', type=str, default='sft_vlm', help='保存权重前缀')
+    parser.add_argument('--epochs', type=int, default=2, help='训练轮数')
+    parser.add_argument('--batch_size', type=int, default=4, help='batch size')
+    parser.add_argument('--learning_rate', type=float, default=1e-6, help='初始学习率')
+    parser.add_argument('--device', type=str, default='cuda:0' if torch.cuda.is_available() else 'cpu', help='训练设备')
+    parser.add_argument('--dtype', type=str, default='bfloat16', choices=['bfloat16', 'float16'], help='混合精度类型')
+    parser.add_argument('--num_workers', type=int, default=8, help='数据加载线程数')
+    parser.add_argument('--accumulation_steps', type=int, default=1, help='梯度累积步数')
+    parser.add_argument('--grad_clip', type=float, default=1.0, help='梯度裁剪阈值')
+    parser.add_argument('--log_interval', type=int, default=100, help='日志打印间隔')
+    parser.add_argument('--save_interval', type=int, default=100, help='模型保存间隔')
+    parser.add_argument('--hidden_size', type=int, default=512, help='隐藏层维度')
+    parser.add_argument('--num_hidden_layers', type=int, default=8, help='隐藏层数量')
+    parser.add_argument('--max_seq_len', type=int, default=1536, help='最大序列长度')
+    parser.add_argument('--use_moe', type=int, default=0, choices=[0, 1], help='是否启用MoE结构')
+    parser.add_argument('--data_path', type=str, default='../dataset/vlm/sft_data.jsonl', help='训练数据路径')
+    parser.add_argument('--images_path', type=str, default='../dataset/vlm/sft_images', help='训练图像路径')
+    parser.add_argument('--tokenizer_path', type=str, default='../model', help='分词器路径')
+    parser.add_argument('--vision_model_path', type=str, default='../model/vision_model/clip-vit-base-patch16', help='视觉模型路径')
+    parser.add_argument('--from_weight', type=str, default='pretrain_vlm', help='继承的基础权重名称，为none表示不继承')
+    parser.add_argument('--from_resume', type=int, default=0, choices=[0, 1], help='是否自动检测续训')
+    parser.add_argument('--use_wandb', action='store_true', help='是否启用SwanLab/W&B日志')
+    parser.add_argument('--wandb_project', type=str, default='MiniMind-V-SFT', help='SwanLab项目名')
+    args = parser.parse_args()
+
+    local_rank = init_distributed_mode()
+    if dist.is_initialized():
+        args.device = f'cuda:{local_rank}'
+    setup_seed(42 + (dist.get_rank() if dist.is_initialized() else 0))
+
+    os.makedirs(args.save_dir, exist_ok=True)
+    vlm_config = VLMConfig(
+        hidden_size=args.hidden_size,
+        num_hidden_layers=args.num_hidden_layers,
+        max_seq_len=args.max_seq_len,
+        use_moe=bool(args.use_moe),
+    )
+    ckp_data = vlm_checkpoint(vlm_config, weight=args.save_weight, save_dir='../checkpoints') if args.from_resume == 1 else None
+
+    device_type = 'cuda' if 'cuda' in args.device else 'cpu'
+    dtype = torch.bfloat16 if args.dtype == 'bfloat16' else torch.float16
+    autocast_ctx = nullcontext() if device_type == 'cpu' else torch.cuda.amp.autocast(dtype=dtype)
+
+    wandb = None
+    if args.use_wandb and is_main_process():
+        import swanlab as wandb
+        wandb_id = ckp_data.get('wandb_id') if ckp_data else None
+        resume = 'must' if wandb_id else None
+        wandb_run_name = f"MiniMind-V-SFT-Epoch-{args.epochs}-BatchSize-{args.batch_size}-LearningRate-{args.learning_rate}"
+        wandb.init(project=args.wandb_project, name=wandb_run_name, id=wandb_id, resume=resume)
+
+    model, tokenizer, preprocess = init_vlm_model(
+        vlm_config,
+        from_weight=args.from_weight,
+        tokenizer_path=args.tokenizer_path,
+        vision_model_path=args.vision_model_path,
+        save_dir=args.save_dir,
+        device=args.device,
+    )
+
+    train_ds = VLMDataset(
+        args.data_path,
+        args.images_path,
+        tokenizer,
+        preprocess=preprocess,
+        image_special_token=vlm_config.image_special_token,
+        max_length=vlm_config.max_seq_len,
+    )
+    train_sampler = DistributedSampler(train_ds) if dist.is_initialized() else None
+    scaler = torch.cuda.amp.GradScaler(enabled=(args.dtype == 'float16'))
+    optimizer = optim.AdamW(model.parameters(), lr=args.learning_rate)
+
+    start_epoch, start_step = 0, 0
+    if ckp_data:
+        model.load_state_dict(ckp_data['model'], strict=False)
+        if ckp_data.get('optimizer'):
+            optimizer.load_state_dict(ckp_data['optimizer'])
+        if ckp_data.get('scaler'):
+            scaler.load_state_dict(ckp_data['scaler'])
+        start_epoch = ckp_data.get('epoch', 0)
+        start_step = ckp_data.get('step', 0)
+
+    if dist.is_initialized():
+        model._ddp_params_and_buffers_to_ignore = {"pos_cis"}
+        model = DistributedDataParallel(model, device_ids=[local_rank])
+
+    for epoch in range(start_epoch, args.epochs):
+        if train_sampler:
+            train_sampler.set_epoch(epoch)
+
+        if epoch == start_epoch and start_step > 0:
+            sampler_iterable = train_sampler or range(len(train_ds))
+            batch_sampler = SkipBatchSampler(sampler_iterable, args.batch_size, start_step + 1)
+            loader = DataLoader(train_ds, batch_sampler=batch_sampler, num_workers=args.num_workers, pin_memory=True)
+            Logger(f'Epoch [{epoch + 1}/{args.epochs}]: 跳过前{start_step}个step，从step {start_step + 1}开始')
+            train_epoch(args, vlm_config, model, optimizer, scaler, autocast_ctx, loader, epoch, len(loader) + start_step + 1, start_step, wandb)
+        else:
+            loader = DataLoader(
+                train_ds,
+                batch_size=args.batch_size,
+                shuffle=train_sampler is None,
+                sampler=train_sampler,
+                num_workers=args.num_workers,
+                pin_memory=True,
+            )
+            train_epoch(args, vlm_config, model, optimizer, scaler, autocast_ctx, loader, epoch, len(loader), 0, wandb)
+
+
+if __name__ == '__main__':
+    main()

--- a/trainer/trainer_utils.py
+++ b/trainer/trainer_utils.py
@@ -1,0 +1,173 @@
+"""Utility helpers shared by the MiniMind VLM training scripts."""
+from __future__ import annotations
+
+import math
+import os
+import random
+from typing import Dict, Iterable, List, Optional
+
+import numpy as np
+import torch
+import torch.distributed as dist
+from torch.utils.data import Sampler
+from transformers import AutoTokenizer
+
+from model.model_vlm import MiniMindVLM, VLMConfig
+
+
+def is_main_process() -> bool:
+    return not dist.is_initialized() or dist.get_rank() == 0
+
+
+def Logger(content: str) -> None:
+    if is_main_process():
+        print(content)
+
+
+def get_lr(current_step: int, total_steps: int, lr: float) -> float:
+    return lr / 10 + 0.5 * lr * (1 + math.cos(math.pi * current_step / total_steps))
+
+
+def init_distributed_mode() -> int:
+    if int(os.environ.get("RANK", -1)) == -1:
+        return 0
+    dist.init_process_group(backend="nccl")
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    return local_rank
+
+
+def setup_seed(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+
+
+def init_vlm_model(
+    vlm_config: VLMConfig,
+    from_weight: str = "pretrain_vlm",
+    tokenizer_path: str = "../model",
+    vision_model_path: str = "../model/vision_model/clip-vit-base-patch16",
+    save_dir: str = "../out",
+    device: str = "cuda",
+    freeze_llm: bool = False,
+):
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_path)
+    model = MiniMindVLM(vlm_config, vision_model_path=vision_model_path)
+
+    if from_weight != "none":
+        moe_suffix = "_moe" if vlm_config.use_moe else ""
+        weight_path = f"{save_dir}/{from_weight}_{vlm_config.hidden_size}{moe_suffix}.pth"
+        if os.path.exists(weight_path):
+            weights = torch.load(weight_path, map_location=device)
+            model.load_state_dict(weights, strict=False)
+        else:
+            Logger(f"⚠️ 未找到预训练权重 {weight_path}，将从头训练。")
+
+    if freeze_llm:
+        for name, param in model.named_parameters():
+            if "vision_proj" not in name:
+                param.requires_grad = False
+
+    Logger(
+        f"所加载VLM Model可训练参数：{sum(p.numel() for p in model.parameters() if p.requires_grad) / 1e6:.3f} 百万"
+    )
+    preprocess = model.processor
+    return model.to(device), tokenizer, preprocess
+
+
+def vlm_checkpoint(
+    vlm_config: VLMConfig,
+    weight: str = "pretrain_vlm",
+    model: Optional[torch.nn.Module] = None,
+    optimizer: Optional[torch.optim.Optimizer] = None,
+    epoch: int = 0,
+    step: int = 0,
+    wandb=None,
+    save_dir: str = "../checkpoints",
+    **kwargs,
+) -> Optional[Dict[str, torch.Tensor]]:
+    os.makedirs(save_dir, exist_ok=True)
+    moe_path = "_moe" if vlm_config.use_moe else ""
+    ckp_path = f"{save_dir}/{weight}_{vlm_config.hidden_size}{moe_path}.pth"
+    resume_path = f"{save_dir}/{weight}_{vlm_config.hidden_size}{moe_path}_resume.pth"
+
+    if model is not None:
+        from torch.nn.parallel import DistributedDataParallel
+
+        state_dict = model.module.state_dict() if isinstance(model, DistributedDataParallel) else model.state_dict()
+        clean_state_dict = {k: v for k, v in state_dict.items() if not k.startswith("vision_encoder.")}
+        ckp_tmp = ckp_path + ".tmp"
+        torch.save({k: v.half() for k, v in clean_state_dict.items()}, ckp_tmp)
+        os.replace(ckp_tmp, ckp_path)
+
+        wandb_id = None
+        if wandb:
+            if hasattr(wandb, "get_run"):
+                run = wandb.get_run()
+                wandb_id = getattr(run, "id", None) if run else None
+            else:
+                wandb_id = getattr(wandb, "id", None)
+
+        resume_data = {
+            "model": state_dict,
+            "optimizer": optimizer.state_dict() if optimizer else None,
+            "epoch": epoch,
+            "step": step,
+            "world_size": dist.get_world_size() if dist.is_initialized() else 1,
+            "wandb_id": wandb_id,
+        }
+        for key, value in kwargs.items():
+            if value is None:
+                continue
+            if hasattr(value, "state_dict"):
+                resume_data[key] = value.state_dict()
+            else:
+                resume_data[key] = value
+
+        resume_tmp = resume_path + ".tmp"
+        torch.save(resume_data, resume_tmp)
+        os.replace(resume_tmp, resume_path)
+        return None
+
+    if os.path.exists(resume_path):
+        ckp_data = torch.load(resume_path, map_location="cpu")
+        saved_ws = ckp_data.get("world_size", 1)
+        current_ws = dist.get_world_size() if dist.is_initialized() else 1
+        if saved_ws != current_ws and ckp_data.get("step") is not None:
+            ckp_data["step"] = ckp_data["step"] * saved_ws // max(current_ws, 1)
+            Logger(f"GPU数量变化({saved_ws}→{current_ws})，step已自动转换为{ckp_data['step']}")
+        return ckp_data
+    return None
+
+
+class SkipBatchSampler(Sampler[List[int]]):
+    """Sampler that skips the first N batches when resuming training."""
+
+    def __init__(self, sampler: Iterable[int], batch_size: int, skip_batches: int = 0) -> None:
+        self.sampler = list(sampler)
+        self.batch_size = batch_size
+        self.skip_batches = skip_batches
+
+    def __iter__(self):
+        batch: List[int] = []
+        skipped = 0
+        for idx in self.sampler:
+            batch.append(idx)
+            if len(batch) == self.batch_size:
+                if skipped < self.skip_batches:
+                    skipped += 1
+                    batch = []
+                    continue
+                yield batch
+                batch = []
+        if batch and skipped >= self.skip_batches:
+            yield batch
+
+    def __len__(self) -> int:  # pragma: no cover - deterministic calculation
+        total_batches = (len(self.sampler) + self.batch_size - 1) // self.batch_size
+        return max(0, total_batches - self.skip_batches)


### PR DESCRIPTION
## Summary
- add lightweight fallback vision encoder/processor so MiniMind VLM works without CLIP assets
- create CPU-friendly smoke tests that cover a training step and greedy generation

## Testing
- pytest tests/test_vlm_smoke.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69160c7462ec83309c0db29eb01d5f26)