### PR TITLE
Add dashboard for experiment management

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ bash scripts/run_mlx.sh --smoke-test
 - 训练默认集成 [SwanLab](https://swanlab.cn) 与 [Weights & Biases](https://wandb.ai)；
 - 可通过环境变量 `MINILLM_USE_SWANLAB` / `WANDB_API_KEY` 控制启用；
 - 日志与配置保存在 `out/logs/`，便于二次分析。
+- 新增 `scripts/dashboard/` 仪表盘（灵感来自 [llm-madness](https://github.com/MaxHastings/llm-madness)），一站式查看配置模板、数据集与 `out/` 内的运行记录：
+  ```bash
+  python -m scripts.dashboard.app --host 0.0.0.0 --port 8008
+  ```
+  打开页面后可以：
+  - 浏览 `configs/dashboard/*.json` 中的预设管线/训练配置；
+  - 勾选数据文件并合并成 `out/datasets/<name>/combined.jsonl` 快照，自动写入 manifest；
+  - 聚合 `out/` 目录下的 checkpoint、TensorBoard 标量并绘制曲线，便于快速比对训练状态。
 
 ---
 

--- a/configs/dashboard/dpo.json
+++ b/configs/dashboard/dpo.json
@@ -1,0 +1,27 @@
+{
+  "meta": {
+    "name": "DPO 对齐配置",
+    "version": "v1",
+    "stage": "dpo",
+    "description": "使用仓库内置偏好数据进行最小化 DPO 训练，便于在仪表盘中快速对比。"
+  },
+  "args": {
+    "out_dir": "out/dpo_dashboard",
+    "epochs": 1,
+    "batch_size": 8,
+    "learning_rate": 0.0000005,
+    "device": "auto",
+    "dtype": "bfloat16",
+    "accumulation_steps": 1,
+    "grad_clip": 1.0,
+    "log_interval": 20,
+    "save_interval": 100,
+    "hidden_size": 512,
+    "num_hidden_layers": 8,
+    "max_seq_len": 512,
+    "use_moe": false,
+    "data_path": "dataset/preference_cn_sample.jsonl",
+    "tensorboard_dir": "out/logs/dashboard/dpo",
+    "pretrained_path": "out/sft_dashboard/full_sft_512.pth"
+  }
+}

--- a/configs/dashboard/pipeline.json
+++ b/configs/dashboard/pipeline.json
@@ -1,0 +1,40 @@
+{
+  "meta": {
+    "name": "默认三阶段流水线",
+    "version": "v1",
+    "stage": "pipeline",
+    "description": "以仓库内置中文数据跑通预训练→SFT→DPO 的标准流程，并写入 out/logs 下的 TensorBoard 轨迹。"
+  },
+  "paths": {
+    "pretrain_data": "dataset/identity_cn_sample.jsonl",
+    "sft_data": "data/chinese/identity_conversations.jsonl",
+    "dpo_data": "dataset/preference_cn_sample.jsonl",
+    "tensorboard_root": "out/logs/dashboard"
+  },
+  "stages": {
+    "pretrain": {
+      "script": "trainer/train_pretrain.py",
+      "hidden_size": 512,
+      "num_hidden_layers": 8,
+      "batch_size": 32,
+      "max_seq_len": 512,
+      "learning_rate": 0.0005,
+      "epochs": 1,
+      "tensorboard_dir": "out/logs/dashboard/pretrain"
+    },
+    "sft": {
+      "script": "trainer/train_full_sft.py",
+      "batch_size": 16,
+      "learning_rate": 0.0000005,
+      "epochs": 2,
+      "tensorboard_dir": "out/logs/dashboard/sft"
+    },
+    "dpo": {
+      "script": "trainer/train_dpo.py",
+      "batch_size": 8,
+      "learning_rate": 0.0000005,
+      "epochs": 1,
+      "tensorboard_dir": "out/logs/dashboard/dpo"
+    }
+  }
+}

--- a/configs/dashboard/pretrain.json
+++ b/configs/dashboard/pretrain.json
@@ -1,0 +1,29 @@
+{
+  "meta": {
+    "name": "预训练默认配置",
+    "version": "v1",
+    "stage": "pretrain",
+    "description": "与 trainer/train_pretrain.py 参数一致的小型 GPU 预训练配置。"
+  },
+  "args": {
+    "out_dir": "out/pretrain_dashboard",
+    "epochs": 1,
+    "batch_size": 32,
+    "learning_rate": 0.0005,
+    "device": "auto",
+    "dtype": "bfloat16",
+    "use_wandb": false,
+    "num_workers": 2,
+    "ddp": false,
+    "accumulation_steps": 8,
+    "grad_clip": 1.0,
+    "log_interval": 50,
+    "save_interval": 200,
+    "hidden_size": 512,
+    "num_hidden_layers": 8,
+    "max_seq_len": 512,
+    "use_moe": false,
+    "data_path": "dataset/identity_cn_sample.jsonl",
+    "tensorboard_dir": "out/logs/dashboard/pretrain"
+  }
+}

--- a/configs/dashboard/sft.json
+++ b/configs/dashboard/sft.json
@@ -1,0 +1,27 @@
+{
+  "meta": {
+    "name": "指令微调默认配置",
+    "version": "v1",
+    "stage": "sft",
+    "description": "与 trainer/train_full_sft.py 对齐的指令微调参数，支持直接引用预训练 checkpoint。"
+  },
+  "args": {
+    "out_dir": "out/sft_dashboard",
+    "epochs": 2,
+    "batch_size": 16,
+    "learning_rate": 0.0000005,
+    "device": "auto",
+    "dtype": "bfloat16",
+    "accumulation_steps": 1,
+    "grad_clip": 1.0,
+    "log_interval": 50,
+    "save_interval": 200,
+    "hidden_size": 512,
+    "num_hidden_layers": 8,
+    "max_seq_len": 512,
+    "use_moe": false,
+    "data_path": "data/chinese/identity_conversations.jsonl",
+    "tensorboard_dir": "out/logs/dashboard/sft",
+    "pretrained_path": "out/pretrain_dashboard/pretrain_512.pth"
+  }
+}

--- a/scripts/dashboard/__init__.py
+++ b/scripts/dashboard/__init__.py
@@ -1,0 +1,9 @@
+"""Experiment management dashboard for MiniLLM."""
+
+from __future__ import annotations
+
+__all__ = [
+    "create_app",
+]
+
+from .app import create_app

--- a/scripts/dashboard/app.py
+++ b/scripts/dashboard/app.py
@@ -1,0 +1,371 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from flask import Flask, jsonify, render_template, request, send_from_directory
+from tensorboard.backend.event_processing.event_accumulator import EventAccumulator
+
+
+BASE_DIR = Path(__file__).resolve().parent
+REPO_ROOT = BASE_DIR.parents[1]
+DATA_ROOT = REPO_ROOT / "data"
+DATASET_ROOT = REPO_ROOT / "dataset"
+OUT_ROOT = REPO_ROOT / "out"
+CONFIG_ROOT = REPO_ROOT / "configs" / "dashboard"
+
+
+DATA_EXTS = {".jsonl", ".json", ".csv", ".txt"}
+METRIC_TAGS = ("train/loss", "train/lr", "eval/loss", "train/accuracy", "eval/accuracy")
+
+
+@dataclass
+class DatasetRow:
+    path: Path
+    size_bytes: int
+    line_count: int | None
+    line_count_capped: bool
+    modified_at: datetime
+    preview: list[str]
+
+    def to_payload(self) -> dict:
+        return {
+            "path": str(self.path.relative_to(REPO_ROOT)),
+            "size_bytes": self.size_bytes,
+            "line_count": self.line_count,
+            "line_count_capped": self.line_count_capped,
+            "modified_at": self.modified_at.isoformat(),
+            "preview": self.preview,
+        }
+
+
+@dataclass
+class RunSummary:
+    run_id: str
+    name: str
+    stage: str
+    latest_checkpoint: str | None
+    modified_at: datetime
+    metrics: dict[str, float]
+    tensorboard_root: str | None
+
+    def to_payload(self) -> dict:
+        return {
+            "id": self.run_id,
+            "name": self.name,
+            "stage": self.stage,
+            "latest_checkpoint": self.latest_checkpoint,
+            "modified_at": self.modified_at.isoformat(),
+            "metrics": self.metrics,
+            "tensorboard_root": self.tensorboard_root,
+        }
+
+
+def _now() -> str:
+    return datetime.utcnow().isoformat() + "Z"
+
+
+def _read_preview(path: Path, limit: int = 3) -> list[str]:
+    preview: list[str] = []
+    with path.open("r", encoding="utf-8", errors="ignore") as handle:
+        for idx, line in enumerate(handle):
+            if idx >= limit:
+                break
+            content = line.strip()
+            if content:
+                preview.append(content)
+    return preview
+
+
+def _count_lines(path: Path, cap: int = 50_000) -> tuple[int | None, bool]:
+    count = 0
+    capped = False
+    with path.open("r", encoding="utf-8", errors="ignore") as handle:
+        for count, _ in enumerate(handle, start=1):
+            if count >= cap:
+                capped = True
+                break
+    return (count if count else None), capped
+
+
+def _iter_data_files() -> Iterable[Path]:
+    roots = [DATA_ROOT, DATASET_ROOT, OUT_ROOT / "datasets"]
+    for root in roots:
+        if not root.exists():
+            continue
+        for path in root.rglob("*"):
+            if path.is_file() and path.suffix.lower() in DATA_EXTS and not path.name.startswith("."):
+                yield path
+
+
+def _gather_datasets() -> list[DatasetRow]:
+    datasets: list[DatasetRow] = []
+    for path in sorted(_iter_data_files()):
+        stat = path.stat()
+        line_count, capped = _count_lines(path)
+        datasets.append(
+            DatasetRow(
+                path=path,
+                size_bytes=stat.st_size,
+                line_count=line_count,
+                line_count_capped=capped,
+                modified_at=datetime.fromtimestamp(stat.st_mtime),
+                preview=_read_preview(path),
+            )
+        )
+    return datasets
+
+
+def _safe_snapshot_name(raw: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9._-]", "_", raw).strip("._-")
+    return cleaned or "snapshot"
+
+
+def _resolve_paths(paths: Sequence[str]) -> list[Path]:
+    resolved: list[Path] = []
+    for raw in paths:
+        candidate = Path(raw)
+        if not candidate.is_absolute():
+            candidate = (REPO_ROOT / candidate).resolve()
+        if REPO_ROOT not in candidate.parents and candidate != REPO_ROOT:
+            raise ValueError(f"Path outside repository: {raw}")
+        if not candidate.exists():
+            raise FileNotFoundError(raw)
+        resolved.append(candidate)
+    return resolved
+
+
+def _materialize_dataset(name: str, inputs: Sequence[Path]) -> dict:
+    snapshot_dir = OUT_ROOT / "datasets" / name
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+    combined = snapshot_dir / "combined.jsonl"
+
+    total_lines = 0
+    total_bytes = 0
+    with combined.open("w", encoding="utf-8") as writer:
+        for path in inputs:
+            with path.open("r", encoding="utf-8", errors="ignore") as reader:
+                for line in reader:
+                    writer.write(line)
+                    total_lines += 1
+            total_bytes += path.stat().st_size
+
+    manifest = {
+        "name": name,
+        "created_at": _now(),
+        "source_files": [str(p.relative_to(REPO_ROOT)) for p in inputs],
+        "combined_path": str(combined.relative_to(REPO_ROOT)),
+        "line_count": total_lines,
+        "size_bytes": total_bytes,
+    }
+    manifest_path = snapshot_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+    return manifest
+
+
+def _infer_stage(path: Path) -> str:
+    parts = [p.lower() for p in path.parts]
+    for token, stage in {
+        "pretrain": "pretrain",
+        "sft": "sft",
+        "dpo": "dpo",
+        "ppo": "ppo",
+        "grpo": "grpo",
+        "distill": "distill",
+    }.items():
+        if any(token in part for part in parts):
+            return stage
+    return "unknown"
+
+
+def _iter_run_roots() -> Iterable[Path]:
+    if not OUT_ROOT.exists():
+        return []
+    candidates: set[Path] = set()
+    for child in OUT_ROOT.iterdir():
+        candidates.add(child)
+    for event_file in OUT_ROOT.rglob("events.out.tfevents.*"):
+        candidates.add(event_file.parent)
+    for ckpt_dir in OUT_ROOT.rglob("checkpoints"):
+        candidates.add(ckpt_dir.parent)
+        if ckpt_dir.parent.parent != OUT_ROOT:
+            candidates.add(ckpt_dir.parent.parent)
+    return sorted(candidates)
+
+
+def _latest_checkpoint(path: Path) -> Path | None:
+    checkpoints: list[Path] = []
+    if path.is_file() and path.suffix in {".pth", ".safetensors"}:
+        checkpoints.append(path)
+    if path.is_dir():
+        for suffix in ("*.pth", "*.safetensors"):
+            checkpoints.extend(path.rglob(suffix))
+    if not checkpoints:
+        return None
+    checkpoints.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    return checkpoints[0]
+
+
+def _find_event_file(path: Path) -> Path | None:
+    if path.is_file() and path.name.startswith("events.out.tfevents"):
+        return path
+    if not path.exists():
+        return None
+    candidates = sorted(path.rglob("events.out.tfevents.*"), key=lambda p: p.stat().st_mtime, reverse=True)
+    return candidates[0] if candidates else None
+
+
+def _load_scalars(event_path: Path) -> dict[str, list[dict]]:
+    try:
+        acc = EventAccumulator(str(event_path))
+        acc.Reload()
+    except Exception:
+        return {}
+
+    tag_map = acc.Tags().get("scalars", [])
+    series: dict[str, list[dict]] = {}
+    for tag in METRIC_TAGS:
+        if tag not in tag_map:
+            continue
+        events = acc.Scalars(tag)
+        series[tag] = [{"step": e.step, "value": e.value, "wall_time": e.wall_time} for e in events]
+    return series
+
+
+def _summaries() -> list[RunSummary]:
+    runs: list[RunSummary] = []
+    for root in _iter_run_roots():
+        if not root.exists():
+            continue
+        latest = _latest_checkpoint(root)
+        event_file = _find_event_file(root)
+        if not latest and not event_file:
+            continue
+        metrics: dict[str, float] = {}
+        if event_file:
+            scalars = _load_scalars(event_file)
+            for key, values in scalars.items():
+                if values:
+                    metrics[key] = values[-1]["value"]
+        try:
+            modified = datetime.fromtimestamp(root.stat().st_mtime)
+        except FileNotFoundError:
+            continue
+        runs.append(
+            RunSummary(
+                run_id=str(root.relative_to(REPO_ROOT)),
+                name=root.name,
+                stage=_infer_stage(root),
+                latest_checkpoint=str(latest.relative_to(REPO_ROOT)) if latest else None,
+                modified_at=modified,
+                metrics=metrics,
+                tensorboard_root=str(event_file.parent.relative_to(REPO_ROOT)) if event_file else None,
+            )
+        )
+    runs.sort(key=lambda r: r.modified_at, reverse=True)
+    return runs
+
+
+def _load_configs() -> list[dict]:
+    configs: list[dict] = []
+    if not CONFIG_ROOT.exists():
+        return configs
+    for path in sorted(CONFIG_ROOT.rglob("*.json")):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        meta = data.get("meta", {}) if isinstance(data, dict) else {}
+        configs.append(
+            {
+                "name": meta.get("name") or path.stem,
+                "version": meta.get("version"),
+                "stage": meta.get("stage"),
+                "description": meta.get("description"),
+                "path": str(path.relative_to(REPO_ROOT)),
+                "content": data,
+            }
+        )
+    return configs
+
+
+def create_app() -> Flask:
+    app = Flask(
+        __name__,
+        template_folder=str(BASE_DIR / "templates"),
+        static_folder=str(BASE_DIR / "static"),
+    )
+
+    @app.route("/")
+    def index() -> str:
+        return render_template("index.html")
+
+    @app.route("/static/<path:filename>")
+    def static_assets(filename: str):  # type: ignore[override]
+        return send_from_directory(app.static_folder, filename)
+
+    @app.route("/api/overview")
+    def overview():
+        datasets = _gather_datasets()
+        runs = _summaries()
+        configs = _load_configs()
+        return jsonify(
+            {
+                "datasets": len(datasets),
+                "runs": len(runs),
+                "configs": len(configs),
+                "latest_run": runs[0].to_payload() if runs else None,
+            }
+        )
+
+    @app.route("/api/datasets")
+    def datasets():
+        return jsonify([row.to_payload() for row in _gather_datasets()])
+
+    @app.route("/api/datasets/materialize", methods=["POST"])
+    def datasets_materialize():
+        payload = request.get_json(force=True) or {}
+        files = payload.get("files") or []
+        name_raw = payload.get("name") or f"snapshot-{datetime.utcnow().strftime('%Y%m%d-%H%M%S')}"
+        if not files:
+            return jsonify({"error": "No input files supplied"}), 400
+        resolved = _resolve_paths(files)
+        manifest = _materialize_dataset(_safe_snapshot_name(name_raw), resolved)
+        return jsonify(manifest)
+
+    @app.route("/api/configs")
+    def configs():
+        return jsonify(_load_configs())
+
+    @app.route("/api/runs")
+    def runs():
+        return jsonify([run.to_payload() for run in _summaries()])
+
+    @app.route("/api/runs/<path:run_id>/scalars")
+    def run_scalars(run_id: str):
+        run_path = (REPO_ROOT / run_id).resolve()
+        if REPO_ROOT not in run_path.parents and run_path != REPO_ROOT:
+            return jsonify({"error": "Run path outside repository"}), 400
+        event_file = _find_event_file(run_path)
+        if not event_file:
+            return jsonify({"scalars": {}})
+        return jsonify({"scalars": _load_scalars(event_file)})
+
+    return app
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="MiniLLM dashboard server")
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8008)
+    parser.add_argument("--debug", action="store_true")
+    args = parser.parse_args()
+
+    app = create_app()
+    app.run(host=args.host, port=args.port, debug=args.debug)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dashboard/static/dashboard.js
+++ b/scripts/dashboard/static/dashboard.js
@@ -1,0 +1,220 @@
+async function fetchJSON(url, options = {}) {
+  const res = await fetch(url, options);
+  if (!res.ok) {
+    throw new Error(`请求失败: ${res.status}`);
+  }
+  return res.json();
+}
+
+function fmtBytes(bytes) {
+  if (!bytes && bytes !== 0) return '未知';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let size = bytes;
+  let idx = 0;
+  while (size >= 1024 && idx < units.length - 1) {
+    size /= 1024;
+    idx += 1;
+  }
+  return `${size.toFixed(size < 10 ? 1 : 0)} ${units[idx]}`;
+}
+
+function fmtLines(n, capped) {
+  if (!n) return '未知';
+  return capped ? `${n}+` : `${n}`;
+}
+
+function renderOverview(data) {
+  const container = document.getElementById('overview');
+  container.innerHTML = '';
+  const cards = [
+    { label: '数据集', value: data.datasets, accent: '#d1d5db' },
+    { label: '运行记录', value: data.runs, accent: '#cbd5e1' },
+    { label: '配置模板', value: data.configs, accent: '#e5e7eb' },
+  ];
+  cards.forEach((item) => {
+    const div = document.createElement('div');
+    div.className = 'card';
+    div.innerHTML = `
+      <h3>${item.label}</h3>
+      <div class="stat" style="color:${item.accent}">${item.value ?? 0}</div>
+      <div class="muted">实时统计</div>
+    `;
+    container.appendChild(div);
+  });
+
+  const tag = document.getElementById('latest-run-tag');
+  if (data.latest_run) {
+    const run = data.latest_run;
+    tag.textContent = `最近运行 · ${run.name} (${run.stage})`;
+  } else {
+    tag.textContent = '最近运行：暂无记录';
+  }
+}
+
+function renderDatasets(rows) {
+  const tbody = document.querySelector('#dataset-table tbody');
+  tbody.innerHTML = '';
+  if (!rows.length) {
+    tbody.innerHTML = '<tr><td colspan="5" class="muted">未找到数据文件</td></tr>';
+    return;
+  }
+  rows.forEach((row) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td><input type="checkbox" data-path="${row.path}"></td>
+      <td><div style="font-family:monospace; font-size:13px;">${row.path}</div></td>
+      <td>${fmtLines(row.line_count, row.line_count_capped)}</td>
+      <td>${fmtBytes(row.size_bytes)}</td>
+      <td class="muted">${row.preview.slice(0, 2).map((p) => p.replace(/</g, '&lt;')).join('<br>')}</td>
+    `;
+    tbody.appendChild(tr);
+  });
+}
+
+function renderConfigs(configs) {
+  const grid = document.getElementById('config-grid');
+  grid.innerHTML = '';
+  if (!configs.length) {
+    grid.innerHTML = '<div class="card muted">暂无配置模板</div>';
+    return;
+  }
+  configs.forEach((cfg) => {
+    const div = document.createElement('div');
+    div.className = 'card';
+    const meta = cfg.content.meta || {};
+    const stage = meta.stage || 'pipeline';
+    div.innerHTML = `
+      <div style="display:flex; justify-content:space-between; align-items:center;">
+        <h3>${cfg.name}</h3>
+        <span class="tag">${stage}</span>
+      </div>
+      <div class="muted" style="margin-bottom:8px;">版本：${cfg.version || '未标注'}</div>
+      <div class="muted" style="font-size:13px; line-height:1.6;">${cfg.description || '配置文件已准备好，可用于 run.sh 或 mlx 训练脚本。'}</div>
+      <div class="muted" style="margin-top:8px; font-family:monospace;">${cfg.path}</div>
+    `;
+    grid.appendChild(div);
+  });
+}
+
+function grayscalePalette(index) {
+  const shades = ['#e5e7eb', '#cbd5e1', '#94a3b8', '#6b7280'];
+  return shades[index % shades.length];
+}
+
+async function drawChart(canvasId, scalars) {
+  const ctx = document.getElementById(canvasId);
+  if (!ctx) return;
+  const datasets = Object.entries(scalars)
+    .filter(([, values]) => values && values.length)
+    .map(([tag, values]) => ({
+      label: tag,
+      data: values.map((v) => ({ x: v.step, y: v.value })),
+      fill: false,
+      borderWidth: 2,
+      borderColor: grayscalePalette(Object.keys(scalars).indexOf(tag)),
+      backgroundColor: 'rgba(229, 231, 235, 0.08)',
+    }));
+
+  if (!datasets.length) {
+    ctx.replaceWith(Object.assign(document.createElement('div'), { className: 'muted', textContent: '暂无 TensorBoard 标量' }));
+    return;
+  }
+
+  new Chart(ctx, {
+    type: 'line',
+    data: { datasets },
+    options: {
+      responsive: true,
+      plugins: { legend: { display: true, labels: { color: '#cbd5e1' } } },
+      scales: {
+        x: { type: 'linear', ticks: { color: '#94a3b8' }, grid: { color: 'rgba(255,255,255,0.08)' } },
+        y: { ticks: { color: '#94a3b8' }, grid: { color: 'rgba(255,255,255,0.08)' } },
+      },
+    },
+  });
+}
+
+async function renderRuns(runs) {
+  const container = document.getElementById('runs');
+  container.innerHTML = '';
+  if (!runs.length) {
+    container.innerHTML = '<div class="card muted">暂无运行记录</div>';
+    return;
+  }
+
+  for (let i = 0; i < runs.length; i += 1) {
+    const run = runs[i];
+    const card = document.createElement('div');
+    card.className = 'card run-card';
+    const metricLines = Object.entries(run.metrics || {})
+      .map(([k, v]) => `<span class="tag">${k}: ${v.toFixed(4)}</span>`)
+      .join(' ');
+    card.innerHTML = `
+      <div>
+        <div style="display:flex; align-items:center; gap:8px;">
+          <h3 style="margin:0;">${run.name}</h3>
+          <span class="tag">${run.stage}</span>
+        </div>
+        <div class="muted" style="margin:4px 0;">最近修改：${new Date(run.modified_at).toLocaleString()}</div>
+        <div class="muted" style="margin:4px 0;">${run.latest_checkpoint ? `Checkpoint: ${run.latest_checkpoint}` : '暂无权重文件'}</div>
+        <div style="display:flex; gap:6px; flex-wrap:wrap;">${metricLines || '<span class="muted">暂无标量</span>'}</div>
+      </div>
+      <div><canvas id="chart-${i}" height="120"></canvas></div>
+    `;
+    container.appendChild(card);
+
+    try {
+      const scalars = await fetchJSON(`/api/runs/${encodeURIComponent(run.id)}/scalars`);
+      await drawChart(`chart-${i}`, scalars.scalars || {});
+    } catch (err) {
+      console.error('加载标量失败', err);
+    }
+  }
+}
+
+async function refresh() {
+  const [overview, datasets, configs, runs] = await Promise.all([
+    fetchJSON('/api/overview'),
+    fetchJSON('/api/datasets'),
+    fetchJSON('/api/configs'),
+    fetchJSON('/api/runs'),
+  ]);
+  renderOverview(overview);
+  renderDatasets(datasets);
+  renderConfigs(configs);
+  renderRuns(runs);
+}
+
+async function setupSnapshotBuilder() {
+  const btn = document.getElementById('build-snapshot');
+  btn.addEventListener('click', async () => {
+    const name = document.getElementById('snapshot-name').value.trim();
+    const selected = Array.from(document.querySelectorAll('#dataset-table input[type="checkbox"]:checked'))
+      .map((el) => el.dataset.path);
+    if (!selected.length) {
+      alert('请至少选择一个数据文件');
+      return;
+    }
+    btn.disabled = true;
+    btn.textContent = '生成中...';
+    try {
+      const res = await fetchJSON('/api/datasets/materialize', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, files: selected }),
+      });
+      alert(`快照已生成：${res.combined_path}\n行数：${res.line_count}`);
+      await refresh();
+    } catch (err) {
+      alert(`生成失败：${err.message}`);
+    } finally {
+      btn.disabled = false;
+      btn.textContent = '生成快照';
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  await refresh();
+  setupSnapshotBuilder();
+});

--- a/scripts/dashboard/templates/index.html
+++ b/scripts/dashboard/templates/index.html
@@ -1,0 +1,192 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>MiniLLM 实验看板</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0b0e13;
+      --card: #11161f;
+      --muted: #9ca3af;
+      --accent: #d1d5db;
+      --border: #1c222c;
+      --ink: #e5e7eb;
+      --shadow: rgba(0, 0, 0, 0.35);
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      padding: 24px;
+      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: radial-gradient(circle at 20% 20%, rgba(209, 213, 219, 0.08), transparent 30%),
+                  radial-gradient(circle at 85% 10%, rgba(148, 163, 184, 0.08), transparent 28%),
+                  var(--bg);
+      color: var(--ink);
+      min-height: 100vh;
+    }
+
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 20px;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 26px;
+      letter-spacing: 0.3px;
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      background: rgba(255, 255, 255, 0.04);
+      color: var(--accent);
+      padding: 8px 12px;
+      border-radius: 999px;
+      font-weight: 600;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 16px;
+      margin-bottom: 24px;
+    }
+
+    .card {
+      background: linear-gradient(145deg, rgba(17, 22, 31, 0.95), rgba(13, 16, 23, 0.92));
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 16px;
+      box-shadow: 0 12px 40px var(--shadow);
+    }
+
+    .card h3 {
+      margin: 0 0 6px;
+      font-size: 16px;
+    }
+
+    .muted { color: var(--muted); font-size: 13px; }
+
+    .stat {
+      font-size: 30px;
+      font-weight: 700;
+      margin: 6px 0;
+      color: var(--ink);
+    }
+
+    .tag {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 10px;
+      border-radius: 999px;
+      font-size: 12px;
+      background: rgba(255, 255, 255, 0.06);
+      color: var(--ink);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+    }
+
+    .section-title {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin: 32px 0 12px;
+      font-size: 18px;
+      letter-spacing: 0.2px;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    th, td {
+      text-align: left;
+      padding: 10px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    tr:hover td { background: rgba(56, 189, 248, 0.05); }
+
+    input[type="checkbox"] { accent-color: #d1d5db; }
+
+    .btn {
+      background: linear-gradient(120deg, #d1d5db, #9ca3af);
+      color: #0c0f15;
+      border: none;
+      padding: 10px 16px;
+      border-radius: 10px;
+      font-weight: 700;
+      cursor: pointer;
+      box-shadow: 0 8px 30px rgba(0,0,0,0.2);
+      transition: transform 120ms ease, box-shadow 120ms ease, filter 120ms ease;
+    }
+
+    .btn:hover { transform: translateY(-1px); box-shadow: 0 12px 40px rgba(0,0,0,0.25); filter: brightness(1.03); }
+
+    .stack { display: flex; flex-direction: column; gap: 8px; }
+
+    .run-card { display: grid; grid-template-columns: 1fr 320px; gap: 14px; align-items: center; }
+
+    @media (max-width: 960px) {
+      .run-card { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div>
+      <div class="pill">实验管线 · 可视化</div>
+      <h1>MiniLLM Dashboard</h1>
+      <p class="muted">管理配置、数据集与训练日志，灵感来自 llm-madness</p>
+    </div>
+    <div class="tag" id="latest-run-tag">最近运行：加载中...</div>
+  </header>
+
+  <section class="grid" id="overview"></section>
+
+  <div class="section-title">📚 数据集</div>
+  <div class="card">
+    <div style="display:flex; align-items:center; gap: 12px; margin-bottom: 12px;">
+      <input id="snapshot-name" type="text" placeholder="snapshot name" style="flex:1; padding: 10px; border-radius: 8px; border: 1px solid var(--border); background: #0b1221; color: #e2e8f0;">
+      <button class="btn" id="build-snapshot">生成快照</button>
+    </div>
+    <div class="muted" style="margin-bottom: 8px;">选择数据文件并一键合并为 out/datasets/*/combined.jsonl</div>
+    <div style="overflow:auto;">
+      <table id="dataset-table">
+        <thead>
+          <tr>
+            <th></th>
+            <th>路径</th>
+            <th>行数</th>
+            <th>大小</th>
+            <th>预览</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="section-title">⚙️ 配置模板</div>
+  <div class="grid" id="config-grid"></div>
+
+  <div class="section-title">📈 训练运行</div>
+  <div class="stack" id="runs"></div>
+
+  <script src="{{ url_for('static_assets', filename='dashboard.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a Flask-powered dashboard to browse datasets, configs, run metadata, and TensorBoard scalars
- ship llm-madness-inspired HTML/JS UI plus preset pipeline/pretrain/sft/dpo configs under configs/dashboard
- update the dashboard to a low-saturation monochrome theme with grayscale chart palette

## Testing
- pyright *(fails: existing repository type errors unrelated to the dashboard changes)*
- pytest *(fails: missing libmlx.so on this environment when instantiating VLM models)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959a46a1bd0833090ac6d25dd88a5e1)